### PR TITLE
Improved post build script

### DIFF
--- a/CopyDotNetApi.bat
+++ b/CopyDotNetApi.bat
@@ -1,4 +1,4 @@
-#REM Press Build->Build Solution (F6) or Build->Build FlaxEngine (Shift+F6) to invoke this script automatically form Visual Studio Enviroment
+REM Press Build->Build Solution (F6) or Build->Build FlaxEngine (Shift+F6) to invoke this script automatically form Visual Studio Enviroment
 @echo off
 
 set outputDir=..\Source\Bin\Editor
@@ -9,10 +9,20 @@ if exist %outputDir% (
 	if not exist "%outputAssembliesDir%" (
 		mkdir "%outputAssembliesDir%"
 	)
-	xcopy /i /s /y "FlaxEngine\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
-	xcopy /i /s /y "FlaxEditor\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
+	
+	if [%~1]==[] (
+		xcopy /i /s /y "FlaxEngine\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
+		xcopy /i /s /y "FlaxEditor\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
+	)
+	if [%~1]==[-Engine] (
+		xcopy /i /s /y "FlaxEngine\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
+	)
+	if [%~1]==[-Editor] (
+		xcopy /i /s /y "FlaxEditor\bin" "%outputAssembliesDir%" /exclude:excludedFileList.txt
+	)
+	REM TODO: Warn the user if he passed an invalid argument
 	echo Done!
 )
-#REM Remove "#REM" from lines below to enable automatic flax update with your custom DLLs, and change name of your current project
-#REM taskkill /f /im FlaxEditor.exe /t
-#REM "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
+REM Remove "REM" from lines below to enable automatic flax update with your custom DLLs, and change name of your current project
+REM start /wait taskkill /f /im FlaxEditor.exe /t
+REM start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"

--- a/CopyDotNetApi.bat
+++ b/CopyDotNetApi.bat
@@ -24,5 +24,7 @@ if exist %outputDir% (
 	echo Done!
 )
 REM Remove "REM" from lines below to enable automatic flax update with your custom DLLs, and change name of your current project
+REM if [%~1]==[-Editor] (
 REM start /wait taskkill /f /im FlaxEditor.exe /t
 REM start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
+REM )

--- a/FlaxEditor/FlaxEditor.csproj
+++ b/FlaxEditor/FlaxEditor.csproj
@@ -448,6 +448,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Exec Command="call &quot;$(SolutionDir)onbuild.bat&quot;" Condition=" '$(OS)' == 'Windows_NT' " />
+    <Exec Command="call &quot;$(SolutionDir)onbuild.bat&quot; -Editor" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
 </Project>

--- a/FlaxEngine/FlaxEngine.csproj
+++ b/FlaxEngine/FlaxEngine.csproj
@@ -441,6 +441,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Exec Command="call &quot;$(SolutionDir)onbuild.bat&quot;" Condition=" '$(OS)' == 'Windows_NT' " />
+    <Exec Command="call &quot;$(SolutionDir)onbuild.bat&quot; -Engine" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
 </Project>

--- a/onbuild.bat
+++ b/onbuild.bat
@@ -1,6 +1,6 @@
 @echo off
 
 cd "%~dp0"
-call CopyDotNetApi.bat
+call CopyDotNetApi.bat %1
 SET ERRORLEVEL = 0
 EXIT 0


### PR DESCRIPTION
- Removed the `#`s from the REM lines, since they were causing errors
- Made it possible to pass an optional argument (`-Engine` and `-Editor`) to the script which are used to specify that it should only copy the Editor/Engine files. (Prevents copying files twice)
- It will only start the editor, if the `-Editor` argument has been passed. Also, the editor will be started as a new process (so that it doesn't block the build process)
- `taskkill` is being started as a new process, to suppress the errors