### PR TITLE
Visject Improvements

### DIFF
--- a/FlaxEditor/FlaxEditor.csproj
+++ b/FlaxEditor/FlaxEditor.csproj
@@ -359,7 +359,7 @@
     <Compile Include="Surface\VisjectSurface.ContextMenu.cs" />
     <Compile Include="Surface\VisjectSurface.cs" />
     <Compile Include="Surface\VisjectSurface.DragDrop.cs" />
-    <Compile Include="Surface\VisjectSurface.Mouse.cs" />
+    <Compile Include="Surface\VisjectSurface.Input.cs" />
     <Compile Include="Surface\VisjectSurface.Paramaters.cs" />
     <Compile Include="Surface\VisjectSurface.Serialization.cs" />
     <Compile Include="Undo\Actions\AddRemoveScriptAction.cs" />

--- a/FlaxEditor/Surface/Archetypes/Material.cs
+++ b/FlaxEditor/Surface/Archetypes/Material.cs
@@ -254,7 +254,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 10,
                 Title = "Two Sided Sign",
-                Description = "Scalar valeu with surface side sign. 1 for normal facing, -1 for inverted",
+                Description = "Scalar value with surface side sign. 1 for normal facing, -1 for inverted",
                 Flags = NodeFlags.MaterialOnly,
                 Size = new Vector2(150, 30),
                 Elements = new[]

--- a/FlaxEditor/Surface/Archetypes/Math.cs
+++ b/FlaxEditor/Surface/Archetypes/Math.cs
@@ -108,7 +108,7 @@ namespace FlaxEditor.Surface.Archetypes
             Op2(20, "Dot", "Returns the dot product of A and B", ConnectionType.Vector, ConnectionType.Float, false),
             Op2(21, "Max", "Selects the greater of A and B"),
             Op2(22, "Min", "Selects the lesser of A and B"),
-            Op2(23, "Power", "Returns A raised to the specified at B power", new []{ "**" }),
+            Op2(23, "Power", "Returns A raised to the specified at B power", new []{ "^", "**" }), //TODO: Fight a religious war over which operator is better
             //
             new NodeArchetype
             {

--- a/FlaxEditor/Surface/Archetypes/Math.cs
+++ b/FlaxEditor/Surface/Archetypes/Math.cs
@@ -27,14 +27,19 @@ namespace FlaxEditor.Surface.Archetypes
                 }
             };
         }
-
         private static NodeArchetype Op2(ushort id, string title, string desc, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true)
+        {
+            return Op2(id, title, desc, null, inputType, outputType, isOutputDependant);
+        }
+
+        private static NodeArchetype Op2(ushort id, string title, string desc, string[] altTitles, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true)
         {
             return new NodeArchetype
             {
                 TypeID = id,
                 Title = title,
                 Description = desc,
+                AlternativeTitles = altTitles,
                 Size = new Vector2(110, 40),
                 DefaultType = inputType,
                 IndependentBoxes = new[]
@@ -69,11 +74,11 @@ namespace FlaxEditor.Surface.Archetypes
         /// </summary>
         public static NodeArchetype[] Nodes =
         {
-            Op2(1, "Add", "Result is sum A and B"),
-            Op2(2, "Subtract", "Result is difference A and B"),
-            Op2(3, "Multiply", "Result is A times B"),
-            Op2(4, "Modulo", "Result is remainder A from A divided by B B"),
-            Op2(5, "Divide", "Result is A divided by B"),
+            Op2(1, "Add", "Result is sum A and B", new []{ "+" }),
+            Op2(2, "Subtract", "Result is difference A and B", new []{ "-" }),
+            Op2(3, "Multiply", "Result is A times B", new []{ "*" }),
+            Op2(4, "Modulo", "Result is remainder A from A divided by B B", new []{ "%" }),
+            Op2(5, "Divide", "Result is A divided by B", new []{ "/" }),
             Op1(7, "Absolute", "Result is absolute value of A"),
             Op1(8, "Ceil", "Returns the smallest integer value greater than or equal to A"),
             Op1(9, "Cosine", "Returns cosine of A"),
@@ -103,7 +108,7 @@ namespace FlaxEditor.Surface.Archetypes
             Op2(20, "Dot", "Returns the dot product of A and B", ConnectionType.Vector, ConnectionType.Float, false),
             Op2(21, "Max", "Selects the greater of A and B"),
             Op2(22, "Min", "Selects the lesser of A and B"),
-            Op2(23, "Power", "Returns A raised to the specified at B power"),
+            Op2(23, "Power", "Returns A raised to the specified at B power", new []{ "**" }),
             //
             new NodeArchetype
             {

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -27,11 +27,6 @@ namespace FlaxEditor.Surface.ContextMenu
         public readonly SurfaceType Type;
 
         /// <summary>
-        /// The currently selected group
-        /// </summary>
-        public VisjectCMGroup SelectedGroup;
-
-        /// <summary>
         /// Event fired when any item in this popup menu gets clicked.
         /// </summary>
         public event Action<VisjectCMItem> OnItemClicked;
@@ -124,7 +119,6 @@ namespace FlaxEditor.Surface.ContextMenu
             // Update groups
             for (int i = 0; i < _groups.Count; i++)
                 _groups[i].UpdateFilter(_searchBox.Text);
-            SelectedGroup = _groups.Find(group => group.Visible);
             PerformLayout();
             _searchBox.Focus();
         }
@@ -151,7 +145,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 _groups[i].ResetView();
 
             _searchBox.Clear();
-            SelectedGroup = _groups.Find(group => group.Visible);
 
             IsLayoutLocked = wasLayoutLocked;
             PerformLayout();
@@ -180,9 +173,9 @@ namespace FlaxEditor.Surface.ContextMenu
                 int archetypeIndex = 0;
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    if (!parameters[i].IsPublic)
+                    if(!parameters[i].IsPublic)
                         continue;
-
+                    
                     archetypes[archetypeIndex++] = new NodeArchetype
                     {
                         TypeID = 1,
@@ -254,16 +247,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 Hide();
                 return true;
             }
-            else if (key == Keys.Return)
-            {
-                if (SelectedGroup?.SelectedItem != null) OnClickItem(SelectedGroup?.SelectedItem);
-                return true;
-            }
-            else if (key == Keys.ArrowUp || key == Keys.ArrowDown)
-            {
-                return SelectedGroup.OnKeyDown(key);
-            }
-
             if (_waitingForInput)
             {
                 _waitingForInput = false;

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -266,6 +266,7 @@ namespace FlaxEditor.Surface.ContextMenu
             else if (key == Keys.Return)
             {
                 if (SelectedItem != null) OnClickItem(SelectedItem);
+                else Hide();
                 return true;
             }
             else if (key == Keys.ArrowUp)

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -66,6 +66,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 Bounds = new Rectangle(0, _searchBox.Bottom + 1, Width, Height - _searchBox.Bottom - 2),
                 Parent = this
             };
+
             _panel1 = panel1;
 
             // Create second panel (for groups arrangement)
@@ -278,7 +279,11 @@ namespace FlaxEditor.Surface.ContextMenu
                 if (nextSelectedItem != null)
                 {
                     SelectedItem = nextSelectedItem;
+
+                    // Scroll into view (without smoothing)
+                    _panel1.VScrollBar.SmoothingScale = 0;
                     _panel1.ScrollViewTo(SelectedItem);
+                    _panel1.VScrollBar.SmoothingScale = 1;
                 }
                 return true;
             }

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -332,6 +332,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <summary>
         /// Gets the next siblings of a control that have a specific type.
         /// </summary>
+        /// <typeparam name="T">The type that the controls should have.</typeparam>
         /// <param name="item">A control that is attached to a parent</param>
         /// <returns>An <see cref="IEnumerable{T}"/> with the siblings that come after the current one.</returns>
         private IEnumerable<T> GetNextSiblings<T>(Control item) where T : Control
@@ -358,6 +359,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <summary>
         /// Gets the previous sibling of a control that have a specific type.
         /// </summary>
+        /// <typeparam name="T">The type that the controls should have.</typeparam>
         /// <param name="item">A control that is attached to a parent</param>
         /// <returns>An <see cref="IEnumerable{T}"/> with the siblings that come before the current one.</returns>
         private IEnumerable<T> GetPreviousSiblings<T>(Control item) where T : Control

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -27,6 +27,11 @@ namespace FlaxEditor.Surface.ContextMenu
         public readonly SurfaceType Type;
 
         /// <summary>
+        /// The currently selected group
+        /// </summary>
+        public VisjectCMGroup SelectedGroup;
+
+        /// <summary>
         /// Event fired when any item in this popup menu gets clicked.
         /// </summary>
         public event Action<VisjectCMItem> OnItemClicked;
@@ -119,6 +124,7 @@ namespace FlaxEditor.Surface.ContextMenu
             // Update groups
             for (int i = 0; i < _groups.Count; i++)
                 _groups[i].UpdateFilter(_searchBox.Text);
+            SelectedGroup = _groups.Find(group => group.Visible);
             PerformLayout();
             _searchBox.Focus();
         }
@@ -145,6 +151,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 _groups[i].ResetView();
 
             _searchBox.Clear();
+            SelectedGroup = _groups.Find(group => group.Visible);
 
             IsLayoutLocked = wasLayoutLocked;
             PerformLayout();
@@ -173,9 +180,9 @@ namespace FlaxEditor.Surface.ContextMenu
                 int archetypeIndex = 0;
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    if(!parameters[i].IsPublic)
+                    if (!parameters[i].IsPublic)
                         continue;
-                    
+
                     archetypes[archetypeIndex++] = new NodeArchetype
                     {
                         TypeID = 1,
@@ -247,6 +254,16 @@ namespace FlaxEditor.Surface.ContextMenu
                 Hide();
                 return true;
             }
+            else if (key == Keys.Return)
+            {
+                if (SelectedGroup?.SelectedItem != null) OnClickItem(SelectedGroup?.SelectedItem);
+                return true;
+            }
+            else if (key == Keys.ArrowUp || key == Keys.ArrowDown)
+            {
+                return SelectedGroup.OnKeyDown(key);
+            }
+
             if (_waitingForInput)
             {
                 _waitingForInput = false;

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -1,6 +1,5 @@
 // Copyright (c) 2012-2018 Wojciech Figat. All rights reserved.
 
-using FlaxEngine;
 using FlaxEngine.GUI;
 
 namespace FlaxEditor.Surface.ContextMenu
@@ -32,8 +31,6 @@ namespace FlaxEditor.Surface.ContextMenu
             ContextMenu = cm;
             Archetype = archetype;
         }
-
-        public VisjectCMItem SelectedItem { get; internal set; }
 
         /// <summary>
         /// Resets the view.
@@ -73,32 +70,12 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 Open(false);
                 Visible = true;
-                if (!string.IsNullOrEmpty(filterText) && ContextMenu.SelectedGroup == this)
-                {
-                    if (SelectedItem.Visible)
-                    {
-
-                    }
-                    else
-                        _children[]
-                }
             }
             else
             {
                 // Hide group if none of the items matched the filter
                 Visible = false;
             }
-        }
-
-        /// <inheritdoc />
-        public override bool OnKeyDown(Keys key)
-        {
-            if (key == Keys.ArrowUp || key == Keys.ArrowDown)
-            {
-
-                return true;
-            }
-            return base.OnKeyDown(key);
         }
     }
 }

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2018 Wojciech Figat. All rights reserved.
 
+using FlaxEngine;
 using FlaxEngine.GUI;
 
 namespace FlaxEditor.Surface.ContextMenu
@@ -31,6 +32,8 @@ namespace FlaxEditor.Surface.ContextMenu
             ContextMenu = cm;
             Archetype = archetype;
         }
+
+        public VisjectCMItem SelectedItem { get; internal set; }
 
         /// <summary>
         /// Resets the view.
@@ -70,12 +73,32 @@ namespace FlaxEditor.Surface.ContextMenu
             {
                 Open(false);
                 Visible = true;
+                if (!string.IsNullOrEmpty(filterText) && ContextMenu.SelectedGroup == this)
+                {
+                    if (SelectedItem.Visible)
+                    {
+
+                    }
+                    else
+                        _children[]
+                }
             }
             else
             {
                 // Hide group if none of the items matched the filter
                 Visible = false;
             }
+        }
+
+        /// <inheritdoc />
+        public override bool OnKeyDown(Keys key)
+        {
+            if (key == Keys.ArrowUp || key == Keys.ArrowDown)
+            {
+
+                return true;
+            }
+            return base.OnKeyDown(key);
         }
     }
 }

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -16,8 +16,16 @@ namespace FlaxEditor.Surface.ContextMenu
     {
         private bool _isMouseDown;
         private List<Rectangle> _highlights;
-        private VisjectCMGroup _group;
         private NodeArchetype _archetype;
+
+
+        /// <summary>
+        /// Gets the item's group
+        /// </summary>
+        /// <value>
+        /// The group of the item
+        /// </value>
+        public VisjectCMGroup Group { get; }
 
         /// <summary>
         /// Gets the group archetype.
@@ -25,7 +33,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <value>
         /// The group archetype.
         /// </value>
-        public GroupArchetype GroupArchetype => _group.Archetype;
+        public GroupArchetype GroupArchetype => Group.Archetype;
 
         /// <summary>
         /// Gets the node archetype.
@@ -43,7 +51,7 @@ namespace FlaxEditor.Surface.ContextMenu
         public VisjectCMItem(VisjectCMGroup group, NodeArchetype archetype)
         : base(0, 0, 120, 12)
         {
-            _group = group;
+            Group = group;
             _archetype = archetype;
         }
 
@@ -98,6 +106,9 @@ namespace FlaxEditor.Surface.ContextMenu
             if (IsMouseOver)
                 Render2D.FillRectangle(rect, style.BackgroundHighlighted);
 
+            if (Group.ContextMenu.SelectedItem == this)
+                Render2D.FillRectangle(rect, style.BackgroundSelected);
+
             // Draw all highlights
             if (_highlights != null)
             {
@@ -127,7 +138,7 @@ namespace FlaxEditor.Surface.ContextMenu
             if (buttons == MouseButton.Left && _isMouseDown)
             {
                 _isMouseDown = false;
-                _group.ContextMenu.OnClickItem(this);
+                Group.ContextMenu.OnClickItem(this);
             }
 
             return base.OnMouseUp(location, buttons);

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -98,9 +98,6 @@ namespace FlaxEditor.Surface.ContextMenu
             if (IsMouseOver)
                 Render2D.FillRectangle(rect, style.BackgroundHighlighted);
 
-            if (_group.SelectedItem == this)
-                Render2D.FillRectangle(rect, style.BackgroundSelected);
-
             // Draw all highlights
             if (_highlights != null)
             {

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -44,6 +44,14 @@ namespace FlaxEditor.Surface.ContextMenu
         public NodeArchetype NodeArchetype => _archetype;
 
         /// <summary>
+        /// Gets and sets the data of the node.
+        /// </summary>
+        /// <value>
+        /// The data of the node.
+        /// </value>
+        public object[] Data { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCMItem"/> class.
         /// </summary>
         /// <param name="group">The group.</param>

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -98,6 +98,9 @@ namespace FlaxEditor.Surface.ContextMenu
             if (IsMouseOver)
                 Render2D.FillRectangle(rect, style.BackgroundHighlighted);
 
+            if (_group.SelectedItem == this)
+                Render2D.FillRectangle(rect, style.BackgroundSelected);
+
             // Draw all highlights
             if (_highlights != null)
             {

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FlaxEditor.Utilities;
 using FlaxEngine;
 using FlaxEngine.GUI;
@@ -42,14 +43,6 @@ namespace FlaxEditor.Surface.ContextMenu
         /// The node archetype.
         /// </value>
         public NodeArchetype NodeArchetype => _archetype;
-
-        /// <summary>
-        /// Gets and sets the data of the node.
-        /// </summary>
-        /// <value>
-        /// The data of the node.
-        /// </value>
-        public object[] Data { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCMItem"/> class.
@@ -93,6 +86,20 @@ namespace FlaxEditor.Surface.ContextMenu
                         var end = font.GetCharPosition(_archetype.Title, ranges[i].EndIndex);
                         _highlights.Add(new Rectangle(start.X + 2, 0, end.X - start.X, Height));
                     }
+                    Visible = true;
+                }
+                else if (_archetype.AlternativeTitles.Any(filterText.Equals))
+                {
+                    // Update highlights
+                    if (_highlights == null)
+                        _highlights = new List<Rectangle>(1);
+                    else
+                        _highlights.Clear();
+                    var style = Style.Current;
+                    var font = style.FontSmall;
+                    var start = font.GetCharPosition(_archetype.Title, 0);
+                    var end = font.GetCharPosition(_archetype.Title, _archetype.Title.Length - 1);
+                    _highlights.Add(new Rectangle(start.X + 2, 0, end.X - start.X, Height));
                     Visible = true;
                 }
                 else

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -88,7 +88,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     }
                     Visible = true;
                 }
-                else if (_archetype.AlternativeTitles.Any(filterText.Equals))
+                else if (_archetype.AlternativeTitles?.Any(filterText.Equals) == true)
                 {
                     // Update highlights
                     if (_highlights == null)

--- a/FlaxEditor/Surface/NodeArchetype.cs
+++ b/FlaxEditor/Surface/NodeArchetype.cs
@@ -45,6 +45,11 @@ namespace FlaxEditor.Surface
         public string Description;
 
         /// <summary>
+        /// Alternative node titles.
+        /// </summary>
+        public string[] AlternativeTitles;
+
+        /// <summary>
         /// Default node values.
         /// </summary>
         public object[] DefaultValues;

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -52,10 +52,6 @@ namespace FlaxEditor.Surface
         private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
         {
             var node = SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos));
-            //if (node.GetBoxes().ConvertAll(b => b.IsOutput).Aggregate((a, b) => a && b) && HasSelection) //TODO: No way! You're not getting away with this ***
-            // {
-            //    node.Location += new Vector2(-node.Width - 40, 90 * Selection.Count);
-            //}
 
             var toBeDeselected = new System.Collections.Generic.List<SurfaceNode>();
 

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -21,7 +21,7 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Shows the primary menu.
         /// </summary>
-        /// <param name="location">The location in teh Surface Space.</param>
+        /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
             _cmPrimaryMenu.Show(this, location);
@@ -51,7 +51,25 @@ namespace FlaxEditor.Surface
 
         private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
         {
-            SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos));
+            var node = SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos));
+
+            //Smart(tm) connecting
+            var bothBoxes = Selection
+                .OrderBy(s => s.Top)
+                .SelectMany(s => s.GetBoxes())
+                .Where(box => box.IsOutput)
+                .Zip(
+                    node.GetBoxes()
+                    .Where(box => !box.IsOutput),
+                    (a, b) => new { a, b }); //TODO: refactor to use tuples
+
+            foreach (var dualBox in bothBoxes)
+            {
+                dualBox.a.CreateConnection(dualBox.b);
+                Deselect(dualBox.a.ParentNode);
+            }
+
+            AddToSelection(node);
         }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -51,8 +51,11 @@ namespace FlaxEditor.Surface
 
         private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
         {
-            var node = SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos));
-
+            var node = SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos), visjectCmItem.Data);
+            if (node.GetBoxes().ConvertAll(b => b.IsOutput).Aggregate((a, b) => a && b) && HasSelection) //TODO: No way! You're not getting away with this ***
+            {
+                node.Location += new Vector2(-node.Width - 40, 90 * Selection.Count);
+            }
             //Smart(tm) connecting
             var bothBoxes = Selection
                 .OrderBy(s => s.Top)

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -76,10 +76,10 @@ namespace FlaxEditor.Surface
                         bool connectAnyways = true;
 
                         // Can I rely on the box indices?
-                        // If it's a constant node, it needs some special handling
+                        // If it's a constant node, it needs some special handling (either connect the first box or the other ones, never both)
                         if (outputBox.ParentNode.GroupArchetype.Name == "Constants")
                         {
-                            // Don't always connect this sort of box!
+                            // Don't always connect this sort of box
                             connectAnyways = false;
 
                             // If it's the first box, everything is fine?

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -337,24 +337,29 @@ namespace FlaxEditor.Surface
             {
                 var baseNode = Selection
                                     .OrderBy(s => s.Top)
+                                    .ThenBy(s => -s.Left) //TODO: That has to be improved as well
                                     .First();
-                const float DistanceBetweenNodes = 40;
-                _cmStartPos = baseNode.Location - ViewPosition + new Vector2(baseNode.Width + DistanceBetweenNodes, 0);
 
-                var zeroVector = Vector2.Zero;
-                Vector2.Max(ref _cmStartPos, ref zeroVector, out _cmStartPos);
-                //TODO: Beautify this code ^^ vv
-                //The visject surface has an annoying tendency to lose focus.
+                const float DistanceBetweenNodes = 40; //TODO: Don't just hard code it right here!
+                _cmStartPos = _surface.PointToParent(_surface.Parent, baseNode.Location + new Vector2(baseNode.Width + DistanceBetweenNodes, 0));
+                _cmStartPos = Vector2.Max(_cmStartPos, Vector2.Zero);
 
+                //If the menu is not fully visible, move the surface a bit
+                Vector2 overflow = (_cmStartPos + _cmPrimaryMenu.Size) - _surface.Parent.Size;
+                overflow = Vector2.Max(overflow, Vector2.Zero);
 
+                ViewPosition += overflow;
+                _cmStartPos -= overflow;
+
+                // Show it
                 ShowPrimaryMenu(_cmStartPos);
 
+                // OnKeyDown --> VisjectCM focuses on the text-thingy
                 _cmPrimaryMenu.OnKeyDown(Keys.None);
                 var retVal = _cmPrimaryMenu.OnCharInput(c);
                 _cmPrimaryMenu.OnKeyUp(Keys.None);
 
                 return retVal;
-
             } //TODO: Else?
 
             return base.OnCharInput(c);

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -333,7 +333,8 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool OnCharInput(char c)
         {
-            if (HasSelection)
+            var isChildCharInput = base.OnCharInput(c);
+            if (!isChildCharInput && HasSelection)
             {
                 var baseNode = Selection
                                     .OrderBy(s => s.Top)
@@ -362,7 +363,7 @@ namespace FlaxEditor.Surface
                 return retVal;
             } //TODO: Else?
 
-            return base.OnCharInput(c);
+            return isChildCharInput;
         }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2018 Wojciech Figat. All rights reserved.
 
 using FlaxEngine;
+using System.Linq;
 
 namespace FlaxEditor.Surface
 {
@@ -238,14 +239,6 @@ namespace FlaxEditor.Surface
 
             // Check if any node is under the mouse
             SurfaceNode nodeAtMouse = GetNodeUnderMouse();
-            if (nodeAtMouse == null)
-            {
-                // Check if no move has been made at all
-                if (_mouseMoveAmount < 5.0f)
-                {
-                    ClearSelection();
-                }
-            }
 
             // Cache flags and state
             if (_leftMouseDown && buttons == MouseButton.Left)
@@ -316,25 +309,55 @@ namespace FlaxEditor.Surface
             {
                 switch (key)
                 {
-                case Keys.A:
-                    SelectAll();
-                    return true;
-                case Keys.C:
-                    Copy();
-                    return true;
-                case Keys.V:
-                    Paste();
-                    return true;
-                case Keys.X:
-                    Cut();
-                    return true;
-                case Keys.D:
-                    Duplicate();
-                    return true;
+                    case Keys.A:
+                        SelectAll();
+                        return true;
+                    case Keys.C:
+                        Copy();
+                        return true;
+                    case Keys.V:
+                        Paste();
+                        return true;
+                    case Keys.X:
+                        Cut();
+                        return true;
+                    case Keys.D:
+                        Duplicate();
+                        return true;
                 }
             }
 
             return false;
+        }
+
+        /// <inheritdoc />
+        public override bool OnCharInput(char c)
+        {
+            if (HasSelection)
+            {
+                var baseNode = Selection
+                                    .OrderBy(s => s.Top)
+                                    .First();
+                const float DistanceBetweenNodes = 40;
+                _cmStartPos = baseNode.Location - ViewPosition + new Vector2(baseNode.Width + DistanceBetweenNodes, 0);
+
+                var zeroVector = Vector2.Zero;
+                Vector2.Max(ref _cmStartPos, ref zeroVector, out _cmStartPos);
+                //TODO: Beautify this code ^^ vv
+                //The visject surface has an annoying tendency to lose focus.
+
+
+                ShowPrimaryMenu(_cmStartPos);
+
+                _cmPrimaryMenu.OnKeyDown(Keys.None);
+                var retVal = _cmPrimaryMenu.OnCharInput(c);
+                _cmPrimaryMenu.OnKeyUp(Keys.None);
+
+                return retVal;
+
+            } //TODO: Else?
+
+            return base.OnCharInput(c);
         }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -329,41 +329,5 @@ namespace FlaxEditor.Surface
 
             return false;
         }
-
-        /// <inheritdoc />
-        public override bool OnCharInput(char c)
-        {
-            var isChildCharInput = base.OnCharInput(c);
-            if (!isChildCharInput && HasSelection)
-            {
-                var baseNode = Selection
-                                    .OrderBy(s => s.Top)
-                                    .ThenBy(s => -s.Left) //TODO: That has to be improved as well
-                                    .First();
-
-                const float DistanceBetweenNodes = 40; //TODO: Don't just hard code it right here!
-                _cmStartPos = _surface.PointToParent(_surface.Parent, baseNode.Location + new Vector2(baseNode.Width + DistanceBetweenNodes, 0));
-                _cmStartPos = Vector2.Max(_cmStartPos, Vector2.Zero);
-
-                //If the menu is not fully visible, move the surface a bit
-                Vector2 overflow = (_cmStartPos + _cmPrimaryMenu.Size) - _surface.Parent.Size;
-                overflow = Vector2.Max(overflow, Vector2.Zero);
-
-                ViewPosition += overflow;
-                _cmStartPos -= overflow;
-
-                // Show it
-                ShowPrimaryMenu(_cmStartPos);
-
-                // OnKeyDown --> VisjectCM focuses on the text-thingy
-                _cmPrimaryMenu.OnKeyDown(Keys.None);
-                var retVal = _cmPrimaryMenu.OnCharInput(c);
-                _cmPrimaryMenu.OnKeyUp(Keys.None);
-
-                return retVal;
-            } //TODO: Else?
-
-            return isChildCharInput;
-        }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.Serialization.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Serialization.cs
@@ -97,108 +97,108 @@ namespace FlaxEditor.Surface
 
             switch (type)
             {
-            case 0: // CommonType::Bool:
-                value = stream.ReadByte() != 0;
-                break;
-            case 1: // CommonType::Integer:
-            {
-                value = stream.ReadInt32();
-            }
-                break;
-            case 2: // CommonType::Float:
-            {
-                value = stream.ReadSingle();
-            }
-                break;
-            case 3: // CommonType::Vector2:
-            {
-                value = new Vector2(stream.ReadSingle(), stream.ReadSingle());
-            }
-                break;
-            case 4: // CommonType::Vector3:
-            {
-                value = new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-            }
-                break;
-            case 5: // CommonType::Vector4:
-            {
-                value = new Vector4(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-            }
-                break;
-            case 6: // CommonType::Color:
-            {
-                value = new Color(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-            }
-                break;
-            case 7: // CommonType::Guid:
-            {
-                value = new Guid(stream.ReadBytes(16));
-            }
-                break;
-            case 8: // CommonType::String:
-            {
-                int length = stream.ReadInt32();
-                if (length <= 0)
-                {
-                    value = string.Empty;
-                }
-                else
-                {
-                    var data = new char[length];
-                    for (int i = 0; i < length; i++)
+                case 0: // CommonType::Bool:
+                    value = stream.ReadByte() != 0;
+                    break;
+                case 1: // CommonType::Integer:
                     {
-                        var c = stream.ReadUInt16();
-                        data[i] = (char)(c ^ 953);
+                        value = stream.ReadInt32();
                     }
-                    value = new string(data);
+                    break;
+                case 2: // CommonType::Float:
+                    {
+                        value = stream.ReadSingle();
+                    }
+                    break;
+                case 3: // CommonType::Vector2:
+                    {
+                        value = new Vector2(stream.ReadSingle(), stream.ReadSingle());
+                    }
+                    break;
+                case 4: // CommonType::Vector3:
+                    {
+                        value = new Vector3(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                    }
+                    break;
+                case 5: // CommonType::Vector4:
+                    {
+                        value = new Vector4(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                    }
+                    break;
+                case 6: // CommonType::Color:
+                    {
+                        value = new Color(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                    }
+                    break;
+                case 7: // CommonType::Guid:
+                    {
+                        value = new Guid(stream.ReadBytes(16));
+                    }
+                    break;
+                case 8: // CommonType::String:
+                    {
+                        int length = stream.ReadInt32();
+                        if (length <= 0)
+                        {
+                            value = string.Empty;
+                        }
+                        else
+                        {
+                            var data = new char[length];
+                            for (int i = 0; i < length; i++)
+                            {
+                                var c = stream.ReadUInt16();
+                                data[i] = (char)(c ^ 953);
+                            }
+                            value = new string(data);
+                        }
+                        break;
+                    }
+                /*case 9:// CommonType::Box:
+                {
+                    BoundingBox v;
+                    ReadBox(&v);
+                    data.Set(v);
                 }
-                break;
-            }
-            /*case 9:// CommonType::Box:
-            {
-                BoundingBox v;
-                ReadBox(&v);
-                data.Set(v);
-            }
-                break;
-            case 10:// CommonType::Rotation:
-            {
-                Quaternion v;
-                ReadQuaternion(&v);
-                data.Set(v);
-            }
-                break;
-            case 11:// CommonType::Transform:
-            {
-                Transform v;
-                ReadTransform(&v);
-                data.Set(v);
-            }
-                break;
-            case 12:// CommonType::Sphere:
-            {
-                BoundingSphere v;
-                ReadSphere(&v);
-                data.Set(v);
-            }
-                break;
-            case 13:// CommonType::Rect:
-            {
-                Rect v;
-                ReadRect(&v);
-                data.Set(v);
-            }
-                break;*/
-            case 15: // CommonType::Matrix
-            {
-                value = new Matrix(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
-                                   stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
-                break;
-            }
+                    break;
+                case 10:// CommonType::Rotation:
+                {
+                    Quaternion v;
+                    ReadQuaternion(&v);
+                    data.Set(v);
+                }
+                    break;
+                case 11:// CommonType::Transform:
+                {
+                    Transform v;
+                    ReadTransform(&v);
+                    data.Set(v);
+                }
+                    break;
+                case 12:// CommonType::Sphere:
+                {
+                    BoundingSphere v;
+                    ReadSphere(&v);
+                    data.Set(v);
+                }
+                    break;
+                case 13:// CommonType::Rect:
+                {
+                    Rect v;
+                    ReadRect(&v);
+                    data.Set(v);
+                }
+                    break;*/
+                case 15: // CommonType::Matrix
+                    {
+                        value = new Matrix(stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(),
+                                           stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle(), stream.ReadSingle());
+                        break;
+                    }
 
-            default: throw new SystemException();
+                default: throw new SystemException();
             }
         }
 
@@ -777,6 +777,7 @@ namespace FlaxEditor.Surface
         /// <returns>The bytes with surface data or null if failed.</returns>
         public byte[] Save()
         {
+            var hasFocus = IsFocused;
             Enabled = false;
 
             // Save surface meta
@@ -818,6 +819,7 @@ namespace FlaxEditor.Surface
             }
 
             Enabled = true;
+            if (hasFocus) Focus();
 
             if (result)
             {

--- a/FlaxEditor/Surface/VisjectSurface.cs
+++ b/FlaxEditor/Surface/VisjectSurface.cs
@@ -566,39 +566,39 @@ namespace FlaxEditor.Surface
                 ISurfaceNodeElement element = null;
                 switch (arch.Type)
                 {
-                case NodeElementType.Input:
-                    element = new InputBox(node, arch);
-                    break;
-                case NodeElementType.Output:
-                    element = new OutputBox(node, arch);
-                    break;
-                case NodeElementType.BoolValue:
-                    element = new BoolValue(node, arch);
-                    break;
-                case NodeElementType.FloatValue:
-                    element = new FloatValue(node, arch);
-                    break;
-                case NodeElementType.IntegerValue:
-                    element = new IntegerValue(node, arch);
-                    break;
-                case NodeElementType.ColorValue:
-                    element = new ColorValue(node, arch);
-                    break;
-                case NodeElementType.ComboBox:
-                    element = new ComboBoxElement(node, arch);
-                    break;
-                case NodeElementType.Asset:
-                    element = new AssetSelect(node, arch);
-                    break;
-                case NodeElementType.Text:
-                    element = new TextView(node, arch);
-                    break;
-                case NodeElementType.TextBox:
-                    element = new TextBoxView(node, arch);
-                    break;
-                case NodeElementType.SkeletonNodeSelect:
-                    element = new SkeletonNodeSelectElement(node, arch);
-                    break;
+                    case NodeElementType.Input:
+                        element = new InputBox(node, arch);
+                        break;
+                    case NodeElementType.Output:
+                        element = new OutputBox(node, arch);
+                        break;
+                    case NodeElementType.BoolValue:
+                        element = new BoolValue(node, arch);
+                        break;
+                    case NodeElementType.FloatValue:
+                        element = new FloatValue(node, arch);
+                        break;
+                    case NodeElementType.IntegerValue:
+                        element = new IntegerValue(node, arch);
+                        break;
+                    case NodeElementType.ColorValue:
+                        element = new ColorValue(node, arch);
+                        break;
+                    case NodeElementType.ComboBox:
+                        element = new ComboBoxElement(node, arch);
+                        break;
+                    case NodeElementType.Asset:
+                        element = new AssetSelect(node, arch);
+                        break;
+                    case NodeElementType.Text:
+                        element = new TextView(node, arch);
+                        break;
+                    case NodeElementType.TextBox:
+                        element = new TextBoxView(node, arch);
+                        break;
+                    case NodeElementType.SkeletonNodeSelect:
+                        element = new SkeletonNodeSelectElement(node, arch);
+                        break;
                 }
                 if (element != null)
                 {

--- a/FlaxEditor/Windows/Assets/MaterialWindow.cs
+++ b/FlaxEditor/Windows/Assets/MaterialWindow.cs
@@ -136,22 +136,22 @@ namespace FlaxEditor.Windows.Assets
                         Type pType;
                         switch (p.Type)
                         {
-                        case MaterialParameterType.CubeTexture:
-                            pType = typeof(CubeTexture);
-                            pGuidType = true;
-                            break;
-                        case MaterialParameterType.Texture:
-                        case MaterialParameterType.NormalMap:
-                            pType = typeof(Texture);
-                            pGuidType = true;
-                            break;
-                        case MaterialParameterType.RenderTarget:
-                            pType = typeof(RenderTarget);
-                            pGuidType = true;
-                            break;
-                        default:
-                            pType = p.Value.GetType();
-                            break;
+                            case MaterialParameterType.CubeTexture:
+                                pType = typeof(CubeTexture);
+                                pGuidType = true;
+                                break;
+                            case MaterialParameterType.Texture:
+                            case MaterialParameterType.NormalMap:
+                                pType = typeof(Texture);
+                                pGuidType = true;
+                                break;
+                            case MaterialParameterType.RenderTarget:
+                                pType = typeof(RenderTarget);
+                                pGuidType = true;
+                                break;
+                            default:
+                                pType = p.Value.GetType();
+                                break;
                         }
 
                         var propertyValue = new CustomValueContainer(


### PR DESCRIPTION
Addresses a part of https://github.com/FlaxEngine/FlaxAPI/issues/22
-   Arrow Keys & Enter to choose an autocomplete suggestion
-   Alternative names for nodes (`*` for multiply, `+` for add, ...)
-   Smart:tm: node connecting

-   Visject Surface keeps it's focus on node creation
-   Newly created nodes get added to the selection
-   Node gets removed from selection when you add some connections

- Various minor fixes