### PR TITLE
More Visject Improvements

### DIFF
--- a/CopyDotNetApi.bat
+++ b/CopyDotNetApi.bat
@@ -1,7 +1,7 @@
 REM Press Build->Build Solution (F6) or Build->Build FlaxEngine (Shift+F6) to invoke this script automatically form Visual Studio Enviroment
 @echo off
 
-set outputDir=..\Source\Editor
+set outputDir=..\Source\Bin\Editor
 set outputAssembliesDir=%outputDir%\Assemblies
 
 if exist %outputDir% (
@@ -25,9 +25,11 @@ if exist %outputDir% (
 )
 
 REM Remove "REM" from lines below to enable automatic flax update with your custom DLLs, and change name of your current project
-rem if [%~1]==[-Editor] (
-rem start /wait taskkill /f /im FlaxEditor.exe /t
-rem rem start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
+REM if [%~1]==[-Editor] (
+REM start /wait taskkill /f /im FlaxEditor.exe /t
+REM start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
+REM )
 
-rem powershell start-process "%outputDir%\..\Win64\FlaxEditor.exe" -ArgumentList '-project """%userprofile%\Documents\Flax Projects\MyProject"""'
-rem )
+
+REM If you have powershell installed, this can be used instead of start "Flax Editor - Development Mode"...
+REM powershell start-process "%outputDir%\..\Win64\FlaxEditor.exe" -ArgumentList '-project """%userprofile%\Documents\Flax Projects\MyProject"""'

--- a/CopyDotNetApi.bat
+++ b/CopyDotNetApi.bat
@@ -1,7 +1,7 @@
 REM Press Build->Build Solution (F6) or Build->Build FlaxEngine (Shift+F6) to invoke this script automatically form Visual Studio Enviroment
 @echo off
 
-set outputDir=..\Source\Bin\Editor
+set outputDir=..\Source\Editor
 set outputAssembliesDir=%outputDir%\Assemblies
 
 if exist %outputDir% (
@@ -25,7 +25,9 @@ if exist %outputDir% (
 )
 
 REM Remove "REM" from lines below to enable automatic flax update with your custom DLLs, and change name of your current project
-REM if [%~1]==[-Editor] (
-REM start /wait taskkill /f /im FlaxEditor.exe /t
-REM start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
-REM )
+rem if [%~1]==[-Editor] (
+rem start /wait taskkill /f /im FlaxEditor.exe /t
+rem rem start "Flax Editor - Development Mode" "%outputDir%\..\Win64\FlaxEditor.exe" -project "%userprofile%\Documents\Flax Projects\MyProject"
+
+rem powershell start-process "%outputDir%\..\Win64\FlaxEditor.exe" -ArgumentList '-project """%userprofile%\Documents\Flax Projects\MyProject"""'
+rem )

--- a/FlaxEditor/Surface/Archetypes/Constants.cs
+++ b/FlaxEditor/Surface/Archetypes/Constants.cs
@@ -266,7 +266,10 @@ namespace FlaxEditor.Surface.Archetypes
             },
         };
 
-        private static bool TryParseValues(string filterText, out float[] vector)
+        /// <summary>
+        /// Tries to parse a list of numbers separated by commas
+        /// </summary>
+        private static bool TryParseValues(string filterText, out float[] values)
         {
             float[] vec = new float[4];
             int count = 0;
@@ -288,20 +291,20 @@ namespace FlaxEditor.Surface.Archetypes
                 // If the user inputted something like 3+2.2, it can't be turned into a single node
                 if (filterText.TrimEnd().Length > 0)
                 {
-                    vector = null;
+                    values = null;
                     return false;
                 }
 
                 // And return the values
-                vector = new float[count];
-                for (int i = 0; i < vector.Length; i++)
+                values = new float[count];
+                for (int i = 0; i < values.Length; i++)
                 {
-                    vector[i] = vec[i];
+                    values[i] = vec[i];
                 }
                 return true;
             }
 
-            vector = null;
+            values = null;
             return false;
         }
 

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -18,7 +18,7 @@ namespace FlaxEditor.Surface.ContextMenu
         private bool _isMouseDown;
         private List<Rectangle> _highlights;
         private NodeArchetype _archetype;
-        
+
         /// <summary>
         /// Gets the item's group
         /// </summary>
@@ -42,6 +42,14 @@ namespace FlaxEditor.Surface.ContextMenu
         /// The node archetype.
         /// </value>
         public NodeArchetype NodeArchetype => _archetype;
+
+        /// <summary>
+        /// Gets and sets the data of the node.
+        /// </summary>
+        /// <value>
+        /// The data of the node.
+        /// </value>
+        public object[] Data { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCMItem"/> class.
@@ -69,6 +77,8 @@ namespace FlaxEditor.Surface.ContextMenu
             }
             else
             {
+                object[] data;
+
                 QueryFilterHelper.Range[] ranges;
                 if (QueryFilterHelper.Match(filterText, _archetype.Title, out ranges))
                 {
@@ -100,6 +110,22 @@ namespace FlaxEditor.Surface.ContextMenu
                     var end = font.GetCharPosition(_archetype.Title, _archetype.Title.Length - 1);
                     _highlights.Add(new Rectangle(start.X + 2, 0, end.X - start.X, Height));
                     Visible = true;
+                }
+                else if (NodeArchetype.TryParseText != null && NodeArchetype.TryParseText(filterText, out data))
+                {
+                    // Update highlights
+                    if (_highlights == null)
+                        _highlights = new List<Rectangle>(1);
+                    else
+                        _highlights.Clear();
+                    var style = Style.Current;
+                    var font = style.FontSmall;
+                    var start = font.GetCharPosition(_archetype.Title, 0);
+                    var end = font.GetCharPosition(_archetype.Title, _archetype.Title.Length - 1);
+                    _highlights.Add(new Rectangle(start.X + 2, 0, end.X - start.X, Height));
+                    Visible = true;
+
+                    Data = data;
                 }
                 else
                 {

--- a/FlaxEditor/Surface/NodeArchetype.cs
+++ b/FlaxEditor/Surface/NodeArchetype.cs
@@ -4,6 +4,9 @@ using FlaxEngine;
 
 namespace FlaxEditor.Surface
 {
+
+    public delegate bool NodeArchetypeTryParseHandler(string filterText, out object[] data);
+
     /// <summary>
     /// Surface node archetype description.
     /// </summary>
@@ -73,5 +76,10 @@ namespace FlaxEditor.Surface
         /// Array with default elements descriptions.
         /// </summary>
         public NodeElementArchetype[] Elements;
+
+        /// <summary>
+        /// Tries to parse some text and extract the data from it
+        /// </summary>
+        public NodeArchetypeTryParseHandler TryParseText { get; internal set; }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -24,6 +24,13 @@ namespace FlaxEditor.Surface
         /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
+            //If the menu is not fully visible, move the surface a bit 
+            Vector2 overflow = (location + _cmPrimaryMenu.Size) - _surface.Parent.Size;
+            overflow = Vector2.Max(overflow, Vector2.Zero);
+
+            ViewPosition += overflow;
+            location -= overflow;
+
             _cmPrimaryMenu.Show(this, location);
         }
 

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -24,14 +24,8 @@ namespace FlaxEditor.Surface
         /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
-            //If the menu is not fully visible, move the surface a bit 
-            Vector2 overflow = (location + _cmPrimaryMenu.Size) - _surface.Parent.Size;
-            overflow = Vector2.Max(overflow, Vector2.Zero);
-
-            ViewPosition += overflow;
-            location -= overflow;
-
             _cmPrimaryMenu.Show(this, location);
+            _cmStartPos = location;
         }
 
         /// <summary>
@@ -58,7 +52,12 @@ namespace FlaxEditor.Surface
 
         private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
         {
-            var node = SpawnNode(visjectCmItem.GroupArchetype, visjectCmItem.NodeArchetype, _surface.PointFromParent(_cmStartPos));
+            var node = SpawnNode(
+                    visjectCmItem.GroupArchetype,
+                    visjectCmItem.NodeArchetype,
+                    _surface.PointFromParent(_cmStartPos),
+                    visjectCmItem.Data
+                );
 
             // And, if the user is patiently waiting for his box to get connected to the newly created one
             //   fullfill his wish! #MagicLamp? #Genie?

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -350,31 +350,42 @@ namespace FlaxEditor.Surface
 
         private void CurrentInputTextChanged(string currentInputText)
         {
-            if (!HasInputSelection) return;
+            if (Selection.Count != 1) return;
             if (string.IsNullOrEmpty(currentInputText)) return;
+            if (_cmPrimaryMenu.Visible) return;
 
-            if (!_cmPrimaryMenu.Visible)
+            // # => color
+            // 1,43 => Vector2
+            // Current node should be modify-able
+
+            // Multiple nodes selected?
+
+            var node = Selection[0];
+            var firstOutputBox = node.GetBoxes().DefaultIfEmpty(null).FirstOrDefault(box => box.IsOutput);
+            if (firstOutputBox == null) return;
+
+            _cmStartPos = _surface.PointToParent(_surface.Parent, PositionAfterNode(node));
+            _cmStartPos = Vector2.Max(_cmStartPos, Vector2.Zero);
+
+            //If the menu is not fully visible, move the surface a bit 
+            Vector2 overflow = (_cmStartPos + _cmPrimaryMenu.Size) - _surface.Parent.Size;
+            overflow = Vector2.Max(overflow, Vector2.Zero);
+
+            ViewPosition += overflow;
+            _cmStartPos -= overflow;
+
+            // Show it 
+            _startBox = firstOutputBox;
+            ShowPrimaryMenu(_cmStartPos);
+
+            foreach (char character in currentInputText)
             {
-                var node = Selection[0];
-                var firstOutputBox = node.GetBoxes().DefaultIfEmpty(null).First(box => box.IsOutput);
-                if (firstOutputBox == null) return;
-
-                _cmStartPos = _surface.PointToParent(_surface.Parent, PositionAfterNode(node));
-                _cmStartPos = Vector2.Max(_cmStartPos, Vector2.Zero);
-
-                // Show it 
-                _startBox = firstOutputBox;
-                ShowPrimaryMenu(_cmStartPos);
-
-                foreach (char character in currentInputText)
-                {
-                    // OnKeyDown-- > VisjectCM focuses on the text-thingy
-                    _cmPrimaryMenu.OnKeyDown(Keys.None);
-                    _cmPrimaryMenu.OnCharInput(character);
-                    _cmPrimaryMenu.OnKeyUp(Keys.None);
-                }
-                ResetInputSelection();
+                // OnKeyDown-- > VisjectCM focuses on the text-thingy
+                _cmPrimaryMenu.OnKeyDown(Keys.None);
+                _cmPrimaryMenu.OnCharInput(character);
+                _cmPrimaryMenu.OnKeyUp(Keys.None);
             }
+            ResetInputSelection();
 
             Debug.Log(currentInputText);
         }
@@ -382,7 +393,7 @@ namespace FlaxEditor.Surface
         private Vector2 PositionAfterNode(SurfaceNode node)
         {
             const float DistanceBetweenNodes = 40;
-            //TODO: Doge (Much wow, such spelling) the other nodes 
+            //TODO: Doge the other nodes 
             return node.Location + new Vector2(node.Width + DistanceBetweenNodes, 0);
         }
 

--- a/FlaxEditor/Surface/VisjectSurface.cs
+++ b/FlaxEditor/Surface/VisjectSurface.cs
@@ -276,6 +276,8 @@ namespace FlaxEditor.Surface
         /// </summary>
         public void SelectAll()
         {
+            _hasInputSelectionChanged = true;
+
             for (int i = 0; i < _nodes.Count; i++)
                 _nodes[i].IsSelected = true;
         }
@@ -285,6 +287,8 @@ namespace FlaxEditor.Surface
         /// </summary>
         public void ClearSelection()
         {
+            _hasInputSelectionChanged = true;
+
             for (int i = 0; i < _nodes.Count; i++)
                 _nodes[i].IsSelected = false;
         }
@@ -295,6 +299,8 @@ namespace FlaxEditor.Surface
         /// <param name="node">The node.</param>
         public void AddToSelection(SurfaceNode node)
         {
+            _hasInputSelectionChanged = true;
+
             node.IsSelected = true;
         }
 
@@ -304,6 +310,8 @@ namespace FlaxEditor.Surface
         /// <param name="node">The node.</param>
         public void Select(SurfaceNode node)
         {
+            _hasInputSelectionChanged = true;
+
             ClearSelection();
 
             node.IsSelected = true;
@@ -315,6 +323,8 @@ namespace FlaxEditor.Surface
         /// <param name="nodes">The nodes.</param>
         public void Select(IEnumerable<SurfaceNode> nodes)
         {
+            _hasInputSelectionChanged = true;
+
             ClearSelection();
 
             foreach (var node in nodes)
@@ -329,6 +339,8 @@ namespace FlaxEditor.Surface
         /// <param name="node">The node.</param>
         public void Deselect(SurfaceNode node)
         {
+            _hasInputSelectionChanged = true;
+
             node.IsSelected = false;
         }
 
@@ -338,6 +350,8 @@ namespace FlaxEditor.Surface
         /// <param name="nodes">The nodes.</param>
         public void Delete(IEnumerable<SurfaceNode> nodes)
         {
+            _hasInputSelectionChanged = true;
+
             foreach (var node in nodes)
             {
                 Delete(node);
@@ -350,6 +364,8 @@ namespace FlaxEditor.Surface
         /// <param name="node">The node.</param>
         public void Delete(SurfaceNode node)
         {
+            _hasInputSelectionChanged = true;
+
             if ((node.Archetype.Flags & NodeFlags.NoRemove) == 0)
             {
                 node.RemoveConnections();
@@ -366,6 +382,8 @@ namespace FlaxEditor.Surface
         /// </summary>
         public void Delete()
         {
+            _hasInputSelectionChanged = true;
+
             bool edited = false;
 
             for (int i = 0; i < _nodes.Count; i++)


### PR DESCRIPTION
Implements the following:

- The context menu is now smarter
  - `3` → suggests `float` and `int` and `vector2,3,4`
  - `true` → suggests `bool`
  - `2.5, 5.7, 7.2` → suggests `vector3,4`
  - `#fff` → suggests `color`

Of course, when you spawn the node, it will be spawned with the values that you just typed.

Unimportant things:
- When you have a node selected and start typing, a new node will be created after the current one. This feature isn't very complete and may be improved in future PRs.

- Preparation for fancier features such as being able to edit the current node's values with just the keyboard.

- `CopyDotNetApi.bat`: added an alternative Flax Editor starting command (uses `powershell` instead of `start`)
