### PR TITLE
Default Value Editor for Vector nodes

### DIFF
--- a/FlaxEditor/Surface/Archetypes/Math.cs
+++ b/FlaxEditor/Surface/Archetypes/Math.cs
@@ -28,12 +28,12 @@ namespace FlaxEditor.Surface.Archetypes
             };
         }
 
-        private static NodeArchetype Op2(ushort id, string title, string desc, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true)
+        private static NodeArchetype Op2(ushort id, string title, string desc, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true, object[] defaultValues = null)
         {
-            return Op2(id, title, desc, null, inputType, outputType, isOutputDependant);
+            return Op2(id, title, desc, null, inputType, outputType, isOutputDependant, defaultValues);
         }
 
-        private static NodeArchetype Op2(ushort id, string title, string desc, string[] altTitles, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true)
+        private static NodeArchetype Op2(ushort id, string title, string desc, string[] altTitles, ConnectionType inputType = ConnectionType.Variable, ConnectionType outputType = ConnectionType.Variable, bool isOutputDependant = true, object[] defaultValues = null)
         {
             return new NodeArchetype
             {
@@ -49,7 +49,7 @@ namespace FlaxEditor.Surface.Archetypes
                     1
                 },
                 DependentBoxes = isOutputDependant ? new[] { 2 } : null,
-                DefaultValues = new object[]
+                DefaultValues = defaultValues ?? new object[]
                 {
                     0.0f,
                     0.0f,
@@ -77,9 +77,9 @@ namespace FlaxEditor.Surface.Archetypes
         {
             Op2(1, "Add", "Result is sum A and B", new[] { "+" }),
             Op2(2, "Subtract", "Result is difference A and B", new[] { "-" }),
-            Op2(3, "Multiply", "Result is A times B", new[] { "*" }),
+            Op2(3, "Multiply", "Result is A times B", new[] { "*" }, defaultValues: new object[] {1, 1 }),
             Op2(4, "Modulo", "Result is remainder A from A divided by B B", new[] { "%" }),
-            Op2(5, "Divide", "Result is A divided by B", new[] { "/" }),
+            Op2(5, "Divide", "Result is A divided by B", new[] { "/" }, defaultValues: new object[] {1, 1 }),
             Op1(7, "Absolute", "Result is absolute value of A"),
             Op1(8, "Ceil", "Returns the smallest integer value greater than or equal to A"),
             Op1(9, "Cosine", "Returns cosine of A"),

--- a/FlaxEditor/Surface/Elements/FloatValue.cs
+++ b/FlaxEditor/Surface/Elements/FloatValue.cs
@@ -138,5 +138,40 @@ namespace FlaxEditor.Surface.Elements
 
             parentNode.SetValue(arch.ValueIndex, value);
         }
+
+        public static void SetAllValues(SurfaceNode parentNode, NodeElementArchetype arch, float toSet)
+        {
+            if (arch.ValueIndex < 0)
+                return;
+
+            var value = parentNode.Values[arch.ValueIndex];
+
+            if (value is int)
+            {
+                value = (int)toSet;
+            }
+            else if (value is float)
+            {
+                value = toSet;
+            }
+            else if (value is Vector2)
+            {
+                value = new Vector2(toSet);
+            }
+            else if (value is Vector3)
+            {
+                value = new Vector3(toSet);
+            }
+            else if (value is Vector4)
+            {
+                value = new Vector4(toSet);
+            }
+            else
+            {
+                value = 0;
+            }
+
+            parentNode.SetValue(arch.ValueIndex, value);
+        }
     }
 }

--- a/FlaxEditor/Surface/Elements/InputBox.cs
+++ b/FlaxEditor/Surface/Elements/InputBox.cs
@@ -50,9 +50,11 @@ namespace FlaxEditor.Surface.Elements
                 case ConnectionType.Bool:
                     isValid = _defaultValueEditor is CheckBox;
                     break;
+
                 case ConnectionType.Integer:
                     isValid = _defaultValueEditor is IntValueBox;
                     break;
+
                 case ConnectionType.Float:
                     isValid = _defaultValueEditor is FloatValue;
                     break;
@@ -137,12 +139,32 @@ namespace FlaxEditor.Surface.Elements
                 _defaultValueEditor = control;
                 break;
             }
+            case ConnectionType.Vector2:
+            case ConnectionType.Vector3:
+            case ConnectionType.Vector4:
+            case ConnectionType.Vector:
+            {
+                float value = FloatValue.Get(ParentNode, Archetype);
+                var control = new FloatValueBox(value, x, y, 40, float.MinValue, float.MaxValue, 0.01f)
+                {
+                    Height = height,
+                    Parent = Parent
+                };
+                control.ValueChanged += OnVectorValueBoxChanged;
+                _defaultValueEditor = control;
+                break;
+            }
             }
         }
 
         private void OnCheckBoxChanged(CheckBox checkBox)
         {
             ParentNode.SetValue(Archetype.ValueIndex, checkBox.Checked);
+        }
+
+        private void OnVectorValueBoxChanged()
+        {
+            FloatValue.SetAllValues(ParentNode, Archetype, ((FloatValueBox)_defaultValueEditor).Value);
         }
 
         private void OnFloatValueBoxChanged()


### PR DESCRIPTION
Added a float-default-value-editor for vectors.

And the default value of the `multiply` and `divide` nodes is now 1.