### PR TITLE
Visject improvements 2

### DIFF
--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -22,7 +22,6 @@ namespace FlaxEditor.Surface.ContextMenu
         private VerticalPanel _panel2;
         private Func<List<SurfaceParameter>> _parametersGetter;
         private Elements.Box _startBox;
-        private bool _isNewStartBox;
 
         /// <summary>
         /// The selected item
@@ -254,12 +253,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <inheritdoc />
         public override void Show(Control parent, Vector2 location)
         {
-            if (!_isNewStartBox)
-            {
-                _startBox = null;
-            }
-            _isNewStartBox = false;
-            base.Show(parent, location);
+            Show(parent, location, null);
         }
 
         /// <summary>
@@ -271,8 +265,7 @@ namespace FlaxEditor.Surface.ContextMenu
         public void Show(Control parent, Vector2 location, Elements.Box startBox)
         {
             _startBox = startBox;
-            _isNewStartBox = true;
-            Show(parent, location);
+            base.Show(parent, location);
         }
 
         /// <inheritdoc />

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -19,7 +19,7 @@ namespace FlaxEditor.Surface.ContextMenu
         private bool _waitingForInput;
         private VisjectCMGroup _surfaceParametersGroup;
         private Panel _panel1;
-        private VerticalPanel _panel2;
+        private VerticalPanel _groupsPanel;
         private Func<List<SurfaceParameter>> _parametersGetter;
         private Elements.Box _startBox;
 
@@ -71,7 +71,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 IsScrollable = true,
                 Parent = panel1
             };
-            _panel2 = panel2;
+            _groupsPanel = panel2;
 
             // Init groups
             int index = 0;
@@ -112,31 +112,21 @@ namespace FlaxEditor.Surface.ContextMenu
             if (IsLayoutLocked)
                 return;
 
-            // Sort groups
-            Tuple<float, VisjectCMGroup>[] scores = new Tuple<float, VisjectCMGroup>[_groups.Count];
             for (int i = 0; i < _groups.Count; i++)
             {
-                float groupScore = _groups[i].SortChildrenWithStartBox(_startBox);
-                scores[i] = new Tuple<float, VisjectCMGroup>(groupScore, _groups[i]);
+                _groups[i].UpdateItemSort(_startBox);
             }
 
-            // Code duplication..
-            Array.Sort(scores, (a, b) =>
+            // Sort groups
+            _groupsPanel.SortChildren();
+            // Synchronize with _groups[]
+            for (int i = 0, groupsIndex = 0; i < _groupsPanel.ChildrenCount; i++)
             {
-                // Sort by score (highest to lowest)
-                int sortValue = -1 * a.Item1.CompareTo(b.Item1);
-                if (sortValue == 0)
+                if (_groupsPanel.Children[i] is VisjectCMGroup group)
                 {
-                    // Otherwise, sort them the usual way
-                    sortValue = a.Item2.DefaultIndex.CompareTo(b.Item2.DefaultIndex);
+                    _groups[groupsIndex] = group;
+                    groupsIndex++;
                 }
-                return sortValue;
-            });
-
-            for (int i = 0; i < scores.Length; i++)
-            {
-                _groups[i] = scores[i].Item2;
-                _groups[i].Parent.Children[i] = scores[i].Item2;
             }
 
             // Update groups
@@ -242,7 +232,7 @@ namespace FlaxEditor.Surface.ContextMenu
                 }
                 group.SortChildren();
                 group.UnlockChildrenRecursive();
-                group.Parent = _panel2;
+                group.Parent = _groupsPanel;
                 _groups.Add(group);
                 _surfaceParametersGroup = group;
             }

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -139,8 +139,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 _groups[i].Parent.Children[i] = scores[i].Item2;
             }
 
-            PerformLayout();
-
             // Update groups
             for (int i = 0; i < _groups.Count; i++)
                 _groups[i].UpdateFilter(_searchBox.Text);

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -21,7 +21,7 @@ namespace FlaxEditor.Surface.ContextMenu
         private Panel _panel1;
         private VerticalPanel _groupsPanel;
         private Func<List<SurfaceParameter>> _parametersGetter;
-        private Elements.Box _startBox;
+        private Elements.Box _selectedBox;
 
         /// <summary>
         /// The selected item
@@ -31,7 +31,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <summary>
         /// Event fired when any item in this popup menu gets clicked.
         /// </summary>
-        public event Action<VisjectCMItem> OnItemClicked;
+        public event Action<VisjectCMItem, Elements.Box> OnItemClicked;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCM"/> class.
@@ -112,9 +112,12 @@ namespace FlaxEditor.Surface.ContextMenu
             if (IsLayoutLocked)
                 return;
 
+            // Update groups
             for (int i = 0; i < _groups.Count; i++)
             {
-                _groups[i].UpdateItemSort(_startBox);
+                _groups[i].UpdateFilter(_searchBox.Text);
+
+                _groups[i].UpdateItemSort(_selectedBox);
             }
 
             // Sort groups
@@ -129,9 +132,6 @@ namespace FlaxEditor.Surface.ContextMenu
                 }
             }
 
-            // Update groups
-            for (int i = 0; i < _groups.Count; i++)
-                _groups[i].UpdateFilter(_searchBox.Text);
             //If no item is selected (or it's not visible anymore), select the top one
             if (SelectedItem == null || !SelectedItem.VisibleInHierarchy)
             {
@@ -149,7 +149,7 @@ namespace FlaxEditor.Surface.ContextMenu
         public void OnClickItem(VisjectCMItem item)
         {
             Hide();
-            OnItemClicked?.Invoke(item);
+            OnItemClicked?.Invoke(item, _selectedBox);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <param name="startBox">The currently selected box that the new node will get connected to. Can be null</param>
         public void Show(Control parent, Vector2 location, Elements.Box startBox)
         {
-            _startBox = startBox;
+            _selectedBox = startBox;
             base.Show(parent, location);
         }
 

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -14,6 +14,13 @@ namespace FlaxEditor.Surface.ContextMenu
     /// <seealso cref="FlaxEngine.GUI.ContextMenuBase" />
     public class VisjectCM : ContextMenuBase
     {
+        /// <summary>
+        /// Visject context menu item clicked delegate.
+        /// </summary>
+        /// <param name="clickedItem">The item that was clicked</param>
+        /// <param name="selectedBox">The currently user-selected box. Can be null.</param>
+        public delegate void ItemClickedDelegate(VisjectCMItem clickedItem, Elements.Box selectedBox);
+
         private readonly List<VisjectCMGroup> _groups = new List<VisjectCMGroup>(16);
         private readonly TextBox _searchBox;
         private bool _waitingForInput;
@@ -31,7 +38,7 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <summary>
         /// Event fired when any item in this popup menu gets clicked.
         /// </summary>
-        public event Action<VisjectCMItem, Elements.Box> OnItemClicked;
+        public event ItemClickedDelegate OnItemClicked;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCM"/> class.

--- a/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCM.cs
@@ -127,6 +127,23 @@ namespace FlaxEditor.Surface.ContextMenu
                 _groups[i].UpdateItemSort(_selectedBox);
             }
 
+            SortGroups();
+
+            //If no item is selected (or it's not visible anymore), select the top one
+            if (SelectedItem == null || !SelectedItem.VisibleInHierarchy)
+            {
+                SelectedItem = _groups.Find(g => g.Visible)?.Children.Find(c => c.Visible && c is VisjectCMItem) as VisjectCMItem;
+            }
+            if (SelectedItem != null) _panel1.ScrollViewTo(SelectedItem);
+            PerformLayout();
+            _searchBox.Focus();
+        }
+
+        /// <summary>
+        /// Sort the groups and keeps <see cref="_groups"/> in sync
+        /// </summary>
+        private void SortGroups()
+        {
             // Sort groups
             _groupsPanel.SortChildren();
             // Synchronize with _groups[]
@@ -138,15 +155,6 @@ namespace FlaxEditor.Surface.ContextMenu
                     groupsIndex++;
                 }
             }
-
-            //If no item is selected (or it's not visible anymore), select the top one
-            if (SelectedItem == null || !SelectedItem.VisibleInHierarchy)
-            {
-                SelectedItem = _groups.Find(g => g.Visible)?.Children.Find(c => c.Visible && c is VisjectCMItem) as VisjectCMItem;
-            }
-            if (SelectedItem != null) _panel1.ScrollViewTo(SelectedItem);
-            PerformLayout();
-            _searchBox.Focus();
         }
 
         /// <summary>
@@ -170,6 +178,7 @@ namespace FlaxEditor.Surface.ContextMenu
             for (int i = 0; i < _groups.Count; i++)
                 _groups[i].ResetView();
 
+            SortGroups();
             _searchBox.Clear();
             SelectedItem = null;
             IsLayoutLocked = wasLayoutLocked;

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -48,13 +48,17 @@ namespace FlaxEditor.Surface.ContextMenu
         /// </summary>
         public void ResetView()
         {
+            SortScore = 0;
             // Remove filter
             for (int i = 0; i < _children.Count; i++)
             {
                 if (_children[i] is VisjectCMItem item)
+                {
                     item.UpdateFilter(null);
+                    item.UpdateScore(null);
+                }
             }
-
+            SortChildren();
             Close(false);
             Visible = true;
         }
@@ -96,24 +100,29 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <param name="selectedBox">The currently user-selected box</param>
         public void UpdateItemSort(Box selectedBox)
         {
-            this.SortScore = 0;
+            SortScore = 0;
             for (int i = 0; i < _children.Count; i++)
             {
                 if (_children[i] is VisjectCMItem item)
                 {
                     item.UpdateScore(selectedBox);
 
-                    // Invisible children are irrelevant to the score of this group
-                    if (_children[i].Visible && item.SortScore > this.SortScore)
+                    if (item.SortScore > SortScore)
                     {
-                        this.SortScore = item.SortScore;
+                        SortScore = item.SortScore;
                     }
                 }
+            }
+
+            if (selectedBox == null)
+            {
+                SortScore = 0;
             }
 
             SortChildren();
         }
 
+        /// <inheritdoc/>
         public override int Compare(Control other)
         {
             if (other is VisjectCMGroup otherGroup)

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -96,22 +96,22 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <param name="selectedBox">The currently user-selected box</param>
         public void UpdateItemSort(Box selectedBox)
         {
-            float maxScore = 0;
+            this.SortScore = 0;
             for (int i = 0; i < _children.Count; i++)
             {
                 if (_children[i] is VisjectCMItem item)
                 {
                     item.UpdateScore(selectedBox);
-                    if (item.SortScore > maxScore)
+
+                    // Invisible children are irrelevant to the score of this group
+                    if (_children[i].Visible && item.SortScore > this.SortScore)
                     {
-                        maxScore = item.SortScore;
+                        this.SortScore = item.SortScore;
                     }
                 }
             }
 
             SortChildren();
-
-            SortScore = maxScore;
         }
 
         public override int Compare(Control other)

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMGroup.cs
@@ -1,5 +1,8 @@
 // Copyright (c) 2012-2018 Wojciech Figat. All rights reserved.
 
+using System;
+using System.Collections.Generic;
+using FlaxEditor.Surface.Elements;
 using FlaxEngine.GUI;
 
 namespace FlaxEditor.Surface.ContextMenu
@@ -19,6 +22,8 @@ namespace FlaxEditor.Surface.ContextMenu
         /// The archetype.
         /// </summary>
         public readonly GroupArchetype Archetype;
+
+        internal int DefaultIndex;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCMGroup"/> class.
@@ -76,6 +81,78 @@ namespace FlaxEditor.Surface.ContextMenu
                 // Hide group if none of the items matched the filter
                 Visible = false;
             }
+        }
+
+        public float SortChildrenWithStartBox(Box startBox)
+        {
+            if (startBox == null)
+            {
+                SortChildren();
+                return -1;
+            }
+
+            // Calculate the scores
+            Tuple<float, Control>[] scores = CalculateScores(_children, startBox);
+
+            Array.Sort(scores, (a, b) =>
+            {
+                // Sort by score (highest to lowest)
+                int sortValue = -1 * a.Item1.CompareTo(b.Item1);
+                if (sortValue == 0)
+                {
+                    // Otherwise, sort them the usual way
+                    sortValue = a.Item2.CompareTo(b.Item2);
+                }
+                return sortValue;
+            });
+
+            for (int i = 0; i < _children.Count; i++)
+            {
+                if (scores[i].Item2 is VisjectCMItem item)
+                {
+                    item.Starred = scores[i].Item1 > 0;
+                }
+                _children[i] = scores[i].Item2;
+            }
+            PerformLayout();
+
+            return scores[0].Item1; // Return the highest score
+        }
+
+        private Tuple<float, Control>[] CalculateScores(List<Control> children, Box startBox)
+        {
+            Tuple<float, Control>[] score = new Tuple<float, Control>[children.Count];
+
+            for (int i = 0; i < children.Count; i++)
+            {
+                score[i] = new Tuple<float, Control>(0, children[i]);
+                if (startBox != null)
+                {
+                    if (children[i] is VisjectCMItem item)
+                    {
+                        if (CanConnectTo(startBox, item.NodeArchetype))
+                        {
+                            score[i] = new Tuple<float, Control>(1, children[i]);
+                        }
+                    }
+                }
+            }
+
+            return score;
+        }
+
+        private bool CanConnectTo(Box startBox, NodeArchetype nodeArchetype)
+        {
+            for (int i = 0; i < nodeArchetype.Elements.Length; i++)
+            {
+                if (nodeArchetype.Elements[i].Type == NodeElementType.Input &&
+                    //(startBox.CurrentType & nodeArchetype.Elements[i].ConnectionsType) != 0))
+                    startBox.CanUseType(nodeArchetype.Elements[i].ConnectionsType))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -51,6 +51,8 @@ namespace FlaxEditor.Surface.ContextMenu
         /// </value>
         public object[] Data { get; set; }
 
+        public bool Starred { get; internal set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="VisjectCMItem"/> class.
         /// </summary>
@@ -158,7 +160,7 @@ namespace FlaxEditor.Surface.ContextMenu
             }
 
             // Draw name
-            Render2D.DrawText(style.FontSmall, _archetype.Title, new Rectangle(2, 0, rect.Width - 4, rect.Height), Enabled ? style.Foreground : style.ForegroundDisabled, TextAlignment.Near, TextAlignment.Center);
+            Render2D.DrawText(style.FontSmall, (Starred ? "> " : "") + _archetype.Title, new Rectangle(2, 0, rect.Width - 4, rect.Height), Enabled ? style.Foreground : style.ForegroundDisabled, TextAlignment.Near, TextAlignment.Center);
         }
 
         /// <inheritdoc />

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -75,11 +75,10 @@ namespace FlaxEditor.Surface.ContextMenu
         /// <param name="selectedBox">The currently user-selected box</param>
         public void UpdateScore(Box selectedBox)
         {
-            if (selectedBox == null)
-            {
-                SortScore = 0;
-                return;
-            }
+            // Start off by resetting the score!
+            SortScore = 0;
+
+            if (selectedBox == null) return;
 
             if (CanConnectTo(selectedBox, NodeArchetype))
             {
@@ -90,6 +89,8 @@ namespace FlaxEditor.Surface.ContextMenu
         private bool CanConnectTo(Box startBox, NodeArchetype nodeArchetype)
         {
             if (startBox == null) return false;
+            if (!startBox.IsOutput) return false; // For now, I'm only handing the output box case
+
             for (int i = 0; i < nodeArchetype.Elements.Length; i++)
             {
                 if (nodeArchetype.Elements[i].Type == NodeElementType.Input &&

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -79,8 +79,15 @@ namespace FlaxEditor.Surface.ContextMenu
             SortScore = 0;
 
             if (selectedBox == null) return;
+            if (!(_highlights?.Count > 0)) return;
+            if (!Visible) return;
 
             if (CanConnectTo(selectedBox, NodeArchetype))
+            {
+                SortScore += 1;
+            }
+
+            if (Data != null)
             {
                 SortScore += 1;
             }

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -24,6 +24,9 @@ namespace FlaxEditor.Surface
         /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
+            // Offset added in case the user doesn't like the box and
+            //   wants to quickly get rid of it by clicking
+            location += new Vector2(5);
             _cmPrimaryMenu.Show(this, location, _startBox);
             _cmStartPos = location;
         }

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -59,6 +59,14 @@ namespace FlaxEditor.Surface
             _cmSecondaryMenu.Show(this, location);
         }
 
+        private void OnPrimaryMenuVisibleChanged(Control primaryMenu)
+        {
+            if (!primaryMenu.Visible)
+            {
+                _startBox = null;
+            }
+        }
+
         private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
         {
             var node = SpawnNode(
@@ -69,7 +77,7 @@ namespace FlaxEditor.Surface
             );
 
             // And, if the user is patiently waiting for his box to get connected to the newly created one
-            //   fulfill his wish! #MagicLamp? #Genie?
+            //   fulfill his wish!
             if (_startBox != null)
             {
                 Box alternativeBox = null;

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -24,14 +24,7 @@ namespace FlaxEditor.Surface
         /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
-            if (_startBox != null)
-            {
-                _cmPrimaryMenu.Show(this, location, _startBox);
-            }
-            else
-            {
-                _cmPrimaryMenu.Show(this, location);
-            }
+            _cmPrimaryMenu.Show(this, location, _startBox);
             _cmStartPos = location;
         }
 

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -63,7 +63,7 @@ namespace FlaxEditor.Surface
             }
         }
 
-        private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem)
+        private void OnPrimaryMenuButtonClick(VisjectCMItem visjectCmItem, Box selectedBox)
         {
             var node = SpawnNode(
                 visjectCmItem.GroupArchetype,
@@ -74,18 +74,19 @@ namespace FlaxEditor.Surface
 
             // And, if the user is patiently waiting for his box to get connected to the newly created one
             //   fulfill his wish!
-            if (_startBox != null)
+            if (selectedBox != null)
             {
+                _startBox = selectedBox;
                 Box alternativeBox = null;
-                foreach (var box in node.GetBoxes().Where(box => box.IsOutput != _startBox.IsOutput))
+                foreach (var box in node.GetBoxes().Where(box => box.IsOutput != selectedBox.IsOutput))
                 {
-                    if ((_startBox.CurrentType & box.CurrentType) != 0)
+                    if ((selectedBox.CurrentType & box.CurrentType) != 0)
                     {
                         ConnectingEnd(box);
                         return;
                     }
 
-                    if (alternativeBox == null && _startBox.CanUseType(box.CurrentType))
+                    if (alternativeBox == null && selectedBox.CanUseType(box.CurrentType))
                     {
                         alternativeBox = box;
                     }

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -24,7 +24,14 @@ namespace FlaxEditor.Surface
         /// <param name="location">The location in the Surface Space.</param>
         public void ShowPrimaryMenu(Vector2 location)
         {
-            _cmPrimaryMenu.Show(this, location);
+            if (_startBox != null)
+            {
+                _cmPrimaryMenu.Show(this, location, _startBox);
+            }
+            else
+            {
+                _cmPrimaryMenu.Show(this, location);
+            }
             _cmStartPos = location;
         }
 

--- a/FlaxEditor/Surface/VisjectSurface.CopPaste.cs
+++ b/FlaxEditor/Surface/VisjectSurface.CopPaste.cs
@@ -494,12 +494,12 @@ namespace FlaxEditor.Surface
                     var node = e.Value;
                     var nodeData = nodesData[e.Key];
                     var pos = new Vector2(nodeData.X, nodeData.Y) - upperLeft;
-                    node.Location = ViewPosition + pos + new Vector2(40);
+                    node.Location = ViewPosition + pos + _mousePos / ViewScale;
                 }
                 foreach (var comment in comments)
                 {
                     var pos = comment.Location - upperLeft;
-                    comment.Location = ViewPosition + pos + new Vector2(40);
+                    comment.Location = ViewPosition + pos + _mousePos / ViewScale;
                 }
 
                 // Post load

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -284,10 +284,11 @@ namespace FlaxEditor.Surface
             SurfaceControl controlUnderMouse = GetControlUnderMouse();
 
             // Right clicking while attempting to connect a node to something
-            if (!_rightMouseDown && buttons == MouseButton.Right && !_isMovingSelection && _startBox != null)
+            if (!_rightMouseDown && !_isMovingSelection && _startBox != null)
             {
                 _cmStartPos = location;
                 ShowPrimaryMenu(_cmStartPos);
+                EndMouseCapture();
             }
 
             // Cache flags and state
@@ -343,15 +344,8 @@ namespace FlaxEditor.Surface
             if (base.OnMouseUp(location, buttons))
                 return true;
 
-            if (buttons == MouseButton.Left)
-            {
-                if (!_cmPrimaryMenu.Visible) ConnectingEnd(null);
-                EndMouseCapture();
-            }
-
             return true;
         }
-
 
         /// <inheritdoc />
         public override bool OnCharInput(char c)
@@ -405,14 +399,14 @@ namespace FlaxEditor.Surface
             _cmStartPos = _surface.PointToParent(_surface.Parent, PositionAfterNode(node));
             _cmStartPos = Vector2.Max(_cmStartPos, Vector2.Zero);
 
-            // If the menu is not fully visible, move the surface a bit 
+            // If the menu is not fully visible, move the surface a bit
             Vector2 overflow = (_cmStartPos + _cmPrimaryMenu.Size) - _surface.Parent.Size;
             overflow = Vector2.Max(overflow, Vector2.Zero);
 
             ViewPosition += overflow;
             _cmStartPos -= overflow;
 
-            // Show it 
+            // Show it
             _startBox = firstOutputBox;
             ShowPrimaryMenu(_cmStartPos);
 
@@ -429,7 +423,7 @@ namespace FlaxEditor.Surface
         private Vector2 PositionAfterNode(SurfaceNode node)
         {
             const float DistanceBetweenNodes = 40;
-            //TODO: Doge the other nodes 
+            //TODO: Doge the other nodes
             return node.Location + new Vector2(node.Width + DistanceBetweenNodes, 0);
         }
 
@@ -452,15 +446,19 @@ namespace FlaxEditor.Surface
                 case Keys.A:
                     SelectAll();
                     return true;
+
                 case Keys.C:
                     Copy();
                     return true;
+
                 case Keys.V:
                     Paste();
                     return true;
+
                 case Keys.X:
                     Cut();
                     return true;
+
                 case Keys.D:
                     Duplicate();
                     return true;

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -283,14 +283,6 @@ namespace FlaxEditor.Surface
             // Check if any control is under the mouse
             SurfaceControl controlUnderMouse = GetControlUnderMouse();
 
-            // Right clicking while attempting to connect a node to something
-            if (!_rightMouseDown && !_isMovingSelection && _startBox != null)
-            {
-                _cmStartPos = location;
-                ShowPrimaryMenu(_cmStartPos);
-                EndMouseCapture();
-            }
-
             // Cache flags and state
             if (_leftMouseDown && buttons == MouseButton.Left)
             {
@@ -343,6 +335,14 @@ namespace FlaxEditor.Surface
             // Base
             if (base.OnMouseUp(location, buttons))
                 return true;
+
+            // Right clicking while attempting to connect a node to something
+            if (!_rightMouseDown && !_isMovingSelection && _startBox != null)
+            {
+                _cmStartPos = location;
+                ShowPrimaryMenu(_cmStartPos);
+                EndMouseCapture();
+            }
 
             return true;
         }

--- a/FlaxEditor/Surface/VisjectSurface.cs
+++ b/FlaxEditor/Surface/VisjectSurface.cs
@@ -358,6 +358,7 @@ namespace FlaxEditor.Surface
             // Create primary menu (for nodes spawning)
             _cmPrimaryMenu = primaryContextMenu ?? new VisjectCM(NodeArchetypes, CanSpawnNodeType, () => Parameters);
             _cmPrimaryMenu.OnItemClicked += OnPrimaryMenuButtonClick;
+            _cmPrimaryMenu.VisibleChanged += OnPrimaryMenuVisibleChanged;
 
             // Create secondary menu (for other actions)
             _cmSecondaryMenu = new FlaxEngine.GUI.ContextMenu();
@@ -836,33 +837,43 @@ namespace FlaxEditor.Surface
                 case NodeElementType.Input:
                     element = new InputBox(node, arch);
                     break;
+
                 case NodeElementType.Output:
                     element = new OutputBox(node, arch);
                     break;
+
                 case NodeElementType.BoolValue:
                     element = new BoolValue(node, arch);
                     break;
+
                 case NodeElementType.FloatValue:
                     element = new FloatValue(node, arch);
                     break;
+
                 case NodeElementType.IntegerValue:
                     element = new IntegerValue(node, arch);
                     break;
+
                 case NodeElementType.ColorValue:
                     element = new ColorValue(node, arch);
                     break;
+
                 case NodeElementType.ComboBox:
                     element = new ComboBoxElement(node, arch);
                     break;
+
                 case NodeElementType.Asset:
                     element = new AssetSelect(node, arch);
                     break;
+
                 case NodeElementType.Text:
                     element = new TextView(node, arch);
                     break;
+
                 case NodeElementType.TextBox:
                     element = new TextBoxView(node, arch);
                     break;
+
                 case NodeElementType.SkeletonNodeSelect:
                     element = new SkeletonNodeSelectElement(node, arch);
                     break;


### PR DESCRIPTION
Implements the following Visject improvements
- Visject Context Menu sorting (e.g. currently selected box is a blue texture box --> type `tex` --> first suggestion is `Sample Texture`
- Paste() now pastes at the position of the cursor
- Visject CM pops up on mouse release when creating a new connection
- Visject CM default position is now offset by 5 pixels. This offset was added in case the user doesn't like the CM and wants to quickly get rid of it by clicking.
