### PR TITLE
Align namespace with Visual Studio auto-gen

### DIFF
--- a/FlaxEditor/Content/Proxy/ScriptProxy.cs
+++ b/FlaxEditor/Content/Proxy/ScriptProxy.cs
@@ -44,7 +44,7 @@ namespace FlaxEditor.Content
             // Load template
             var templatePath = StringUtils.CombinePaths(Globals.EditorFolder, "Scripting/ScriptTemplate.cs");
             var scriptTemplate = File.ReadAllText(templatePath);
-            var scriptNamespace = Editor.Instance.ProjectInfo.Name.Replace(" ", "");
+            var scriptNamespace = Editor.Instance.ProjectInfo.Name.Replace(" ", "") + ".Source";
 
             // Get directories
             var sourceDirectory = Globals.ProjectFolder.Replace('\\', '/') + "/Source/";


### PR DESCRIPTION
Visual Studio automatically includes `.Source` in the namespace, because all non-editor scripts are in a solution-folder called `Source`. This pull request makes Flax do the same thing.