### PR TITLE
VectorX & IntX modulus operation support

### DIFF
--- a/FlaxEngine.Tests/FlaxEngine.Tests.csproj
+++ b/FlaxEngine.Tests/FlaxEngine.Tests.csproj
@@ -55,6 +55,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="CircularBufferTests.cs" />
+    <Compile Include="TestModulusOperator.cs" />
     <Compile Include="TestQuaternion.cs" />
     <Compile Include="TestSerialization.cs" />
     <Compile Include="TestStringUtils.cs" />

--- a/FlaxEngine.Tests/TestModulusOperator.cs
+++ b/FlaxEngine.Tests/TestModulusOperator.cs
@@ -1,0 +1,74 @@
+using NUnit.Framework;
+
+namespace FlaxEngine.Tests
+{
+    [TestFixture]
+    public class TestModulusOperator
+    {
+        [Test]
+        public void TestVector3Modulus()
+        {
+            Assert.AreEqual(new Vector3(10, 10, 10) % 3, new Vector3(1, 1, 1));
+            Assert.AreEqual(10 % new Vector3(3, 3, 3), new Vector3(1, 1, 1));
+            Assert.AreEqual(new Vector3(10, 10, 10) % new Vector3(3, 2, 3), new Vector3(1, 0, 1));
+        }
+
+        [Test]
+        public void TestVector2Modulus()
+        {
+            Assert.AreEqual(new Vector2(10, 10) % 3, new Vector2(1, 1));
+            Assert.AreEqual(10 % new Vector2(3, 3), new Vector2(1, 1));
+            Assert.AreEqual(new Vector2(10, 10) % new Vector2(3, 2), new Vector2(1, 0));
+        }
+        
+        [Test]
+        public void TestVector4Modulus()
+        {
+            Assert.AreEqual(new Vector4(10, 10, 10, 10) % 3, new Vector4(1, 1, 1, 1));
+            Assert.AreEqual(10 % new Vector4(3, 3, 3, 3), new Vector4(1, 1, 1, 1));
+            Assert.AreEqual(new Vector4(10, 10, 10, 10) % new Vector4(3, 2, 3, 2), new Vector4(1, 0, 1, 0));
+        }
+        
+        [Test]
+        public void TestInt2Modulus()
+        {
+            Assert.AreEqual(new Int2(10, 10) % 3, new Int2(1, 1));
+            Assert.AreEqual(10 % new Int2(3, 3), new Int2(1, 1));
+            Assert.AreEqual(new Int2(10, 10) % new Int2(3, 2), new Int2(1, 0));
+        }
+        
+        [Test]
+        public void TestInt3Modulus()
+        {
+            Assert.AreEqual(new Int3(10, 10, 10) % 3, new Int3(1, 1, 1));
+            Assert.AreEqual(10 % new Int3(3, 3, 3), new Int3(1, 1, 1));
+            Assert.AreEqual(new Int3(10, 10, 10) % new Int3(3, 2, 3), new Int3(1, 0, 1));
+        }
+        
+        [Test]
+        public void TestInt4Modulus()
+        {
+            Assert.AreEqual(new Int4(10, 10, 10, 10) % 3, new Int4(1, 1, 1, 1));
+            Assert.AreEqual(10 % new Int4(3, 3, 3, 3), new Int4(1, 1, 1, 1));
+            Assert.AreEqual(new Int4(10, 10, 10, 10) % new Int4(3, 2, 3, 2), new Int4(1, 0, 1, 0));
+        }
+        
+        [Test]
+        public void TestHalf2Modulus()
+        {
+            
+        }
+        
+        [Test]
+        public void TestHalf3Modulus()
+        {
+            
+        }
+        
+        [Test]
+        public void TestHalf4Modulus()
+        {
+            
+        }
+    }
+}

--- a/FlaxEngine.Tests/TestModulusOperator.cs
+++ b/FlaxEngine.Tests/TestModulusOperator.cs
@@ -52,23 +52,5 @@ namespace FlaxEngine.Tests
             Assert.AreEqual(10 % new Int4(3, 3, 3, 3), new Int4(1, 1, 1, 1));
             Assert.AreEqual(new Int4(10, 10, 10, 10) % new Int4(3, 2, 3, 2), new Int4(1, 0, 1, 0));
         }
-        
-        [Test]
-        public void TestHalf2Modulus()
-        {
-            
-        }
-        
-        [Test]
-        public void TestHalf3Modulus()
-        {
-            
-        }
-        
-        [Test]
-        public void TestHalf4Modulus()
-        {
-            
-        }
     }
 }

--- a/FlaxEngine/Math/Int2.cs
+++ b/FlaxEngine/Math/Int2.cs
@@ -753,6 +753,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int2 operator %(Int2 value, float scale)
+        {
+            return new Int2((int)(value.X % scale), (int)(value.Y % scale));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int2 operator %(float value, Int2 scale)
+        {
+            return new Int2((int)(value % scale.X), (int)(value % scale.Y));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int2 operator %(Int2 value, Int2 scale)
+        {
+            return new Int2(value.X % scale.X, value.Y % scale.Y);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>

--- a/FlaxEngine/Math/Int3.cs
+++ b/FlaxEngine/Math/Int3.cs
@@ -843,6 +843,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int3 operator %(Int3 value, float scale)
+        {
+            return new Int3((int)(value.X % scale), (int)(value.Y % scale), (int)(value.Z % scale));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int3 operator %(float value, Int3 scale)
+        {
+            return new Int3((int)(value % scale.X), (int)(value % scale.Y), (int)(value % scale.Z));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int3 operator %(Int3 value, Int3 scale)
+        {
+            return new Int3(value.X % scale.X, value.Y % scale.Y, value.Z % scale.Z);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>

--- a/FlaxEngine/Math/Int4.cs
+++ b/FlaxEngine/Math/Int4.cs
@@ -689,6 +689,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int4 operator %(Int4 value, float scale)
+        {
+            return new Int4((int)(value.X % scale), (int)(value.Y % scale), (int)(value.Z % scale), (int)(value.W % scale));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int4 operator %(float value, Int4 scale)
+        {
+            return new Int4((int)(value % scale.X), (int)(value % scale.Y), (int)(value % scale.Z), (int)(value % scale.W));
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Int4 operator %(Int4 value, Int4 scale)
+        {
+            return new Int4(value.X % scale.X, value.Y % scale.Y, value.Z % scale.Z, value.W % scale.W);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>

--- a/FlaxEngine/Math/Vector2.cs
+++ b/FlaxEngine/Math/Vector2.cs
@@ -1591,6 +1591,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector2 operator %(Vector2 value, float scale)
+        {
+            return new Vector2(value.X % scale, value.Y % scale);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector2 operator %(float value, Vector2 scale)
+        {
+            return new Vector2(value % scale.X, value % scale.Y);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector2 operator %(Vector2 value, Vector2 scale)
+        {
+            return new Vector2(value.X % scale.X, value.Y % scale.Y);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>

--- a/FlaxEngine/Math/Vector3.cs
+++ b/FlaxEngine/Math/Vector3.cs
@@ -2003,6 +2003,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector3 operator %(Vector3 value, float scale)
+        {
+            return new Vector3(value.X % scale, value.Y % scale, value.Z % scale);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector3 operator %(float value, Vector3 scale)
+        {
+            return new Vector3(value % scale.X, value % scale.Y, value % scale.Z);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector3 operator %(Vector3 value, Vector3 scale)
+        {
+            return new Vector3(value.X % scale.X, value.Y % scale.Y, value.Z % scale.Z);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>

--- a/FlaxEngine/Math/Vector4.cs
+++ b/FlaxEngine/Math/Vector4.cs
@@ -1377,6 +1377,39 @@ namespace FlaxEngine
         }
 
         /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector4 operator %(Vector4 value, float scale)
+        {
+            return new Vector4(value.X % scale, value.Y % scale, value.Z % scale, value.W % scale);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The amount by which to scale the vector.</param>
+        /// <param name="scale">The vector to scale.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector4 operator %(float value, Vector4 scale)
+        {
+            return new Vector4(value % scale.X, value % scale.Y, value % scale.Z, value % scale.W);
+        }
+        
+        /// <summary>
+        /// Remainder of value divided by scale.
+        /// </summary>
+        /// <param name="value">The vector to scale.</param>
+        /// <param name="scale">The amount by which to scale the vector.</param>
+        /// <returns>The remained vector.</returns>
+        public static Vector4 operator %(Vector4 value, Vector4 scale)
+        {
+            return new Vector4(value.X % scale.X, value.Y % scale.Y, value.Z % scale.Z, value.W % scale.W);
+        }
+        
+        /// <summary>
         /// Perform a component-wise addition
         /// </summary>
         /// <param name="value">The input vector.</param>


### PR DESCRIPTION
I'm adding to `Vector2` `Vector3` `Vector4` `Int2` `Int3` `Int4` modulus support.

Please @mafiesto4 take a look at how is handled modulus in `IntX` classes, i'm just using a float value/scale and casting the result to int. 
Maybe you want a little different behaviour.


**This is my very first `Pull Request` !**