### PR TITLE
Serializable IUndoAction s

### DIFF
--- a/FlaxEditor/History/UndoActionObject.cs
+++ b/FlaxEditor/History/UndoActionObject.cs
@@ -17,6 +17,7 @@ namespace FlaxEditor.History
         /// <summary>
         /// The data value storage to solve issue for flax objects and editor scene tree nodes which are serialized by ref id.
         /// </summary>
+        [Serializable]
         public struct DataValue
         {
             /// <summary>

--- a/FlaxEditor/SceneGraph/GUI/ActorTreeNode.cs
+++ b/FlaxEditor/SceneGraph/GUI/ActorTreeNode.cs
@@ -374,11 +374,19 @@ namespace FlaxEditor.SceneGraph.GUI
             _dragHandlers.OnDragLeave();
         }
 
+        [Serializable]
         private class ReparentAction : IUndoAction
         {
+            [Serialize]
             private Guid[] _ids;
+
+            [Serialize]
             private int _actorsCount;
+
+            [Serialize]
             private Guid[] _prefabIds;
+
+            [Serialize]
             private Guid[] _prefabObjectIds;
 
             public ReparentAction(Actor actor)

--- a/FlaxEditor/Tools/Foliage/Undo/EditFoliageAction.cs
+++ b/FlaxEditor/Tools/Foliage/Undo/EditFoliageAction.cs
@@ -9,10 +9,16 @@ namespace FlaxEditor.Tools.Foliage.Undo
     /// The foliage heightmap or visibility map editing action that records before and after states to swap between unmodified and modified terrain data.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public sealed class EditFoliageAction : IUndoAction
     {
+        [Serialize]
         private readonly Guid _foliageId;
+
+        [Serialize]
         private string _before;
+
+        [Serialize]
         private string _after;
 
         /// <summary>

--- a/FlaxEditor/Tools/Terrain/EditTab.cs
+++ b/FlaxEditor/Tools/Terrain/EditTab.cs
@@ -110,22 +110,26 @@ namespace FlaxEditor.Tools.Terrain
             OnGizmoModeChanged();
         }
 
+        [Serializable]
         private class DeletePatchAction : IUndoAction
         {
-            private readonly Editor _editor;
+            [Serialize]
             private Guid _terrainId;
+
+            [Serialize]
             private Int2 _patchCoord;
+
+            [Serialize]
             private string _data;
 
             /// <inheritdoc />
             public string ActionString => "Delete terrain patch";
 
-            public DeletePatchAction(Editor editor, FlaxEngine.Terrain terrain, ref Int2 patchCoord)
+            public DeletePatchAction(FlaxEngine.Terrain terrain, ref Int2 patchCoord)
             {
                 if (terrain == null)
                     throw new ArgumentException(nameof(terrain));
 
-                _editor = editor ?? throw new ArgumentException(nameof(editor));
                 _terrainId = terrain.ID;
                 _patchCoord = patchCoord;
                 _data = TerrainTools.SerializePatch(terrain, ref patchCoord);
@@ -143,7 +147,7 @@ namespace FlaxEditor.Tools.Terrain
 
                 terrain.RemovePatch(ref _patchCoord);
 
-                _editor.Scene.MarkSceneEdited(terrain.Scene);
+                Editor.Instance.Scene.MarkSceneEdited(terrain.Scene);
             }
 
             /// <inheritdoc />
@@ -159,7 +163,7 @@ namespace FlaxEditor.Tools.Terrain
                 terrain.AddPatch(ref _patchCoord);
                 TerrainTools.DeserializePatch(terrain, ref _patchCoord, _data);
 
-                _editor.Scene.MarkSceneEdited(terrain.Scene);
+                Editor.Instance.Scene.MarkSceneEdited(terrain.Scene);
             }
 
             /// <inheritdoc />
@@ -178,29 +182,37 @@ namespace FlaxEditor.Tools.Terrain
             if (!CarveTab.SelectedTerrain.HasPatch(ref patchCoord))
                 return;
 
-            var action = new DeletePatchAction(CarveTab.Editor, CarveTab.SelectedTerrain, ref patchCoord);
+            var action = new DeletePatchAction(CarveTab.SelectedTerrain, ref patchCoord);
             action.Do();
             CarveTab.Editor.Undo.AddAction(action);
         }
 
+        [Serializable]
         private class EditChunkMaterialAction : IUndoAction
         {
-            private readonly Editor _editor;
+            [Serialize]
             private Guid _terrainId;
+
+            [Serialize]
             private Int2 _patchCoord;
+
+            [Serialize]
             private Int2 _chunkCoord;
+
+            [Serialize]
             private Guid _beforeMaterial;
+
+            [Serialize]
             private Guid _afterMaterial;
 
             /// <inheritdoc />
             public string ActionString => "Edit terrain chunk material";
 
-            public EditChunkMaterialAction(Editor editor, FlaxEngine.Terrain terrain, ref Int2 patchCoord, ref Int2 chunkCoord, MaterialBase toSet)
+            public EditChunkMaterialAction(FlaxEngine.Terrain terrain, ref Int2 patchCoord, ref Int2 chunkCoord, MaterialBase toSet)
             {
                 if (terrain == null)
                     throw new ArgumentException(nameof(terrain));
 
-                _editor = editor ?? throw new ArgumentException(nameof(editor));
                 _terrainId = terrain.ID;
                 _patchCoord = patchCoord;
                 _chunkCoord = chunkCoord;
@@ -236,7 +248,7 @@ namespace FlaxEditor.Tools.Terrain
 
                 terrain.SetChunkOverrideMaterial(ref _patchCoord, ref _chunkCoord, FlaxEngine.Content.LoadAsync<MaterialBase>(ref id));
 
-                _editor.Scene.MarkSceneEdited(terrain.Scene);
+                Editor.Instance.Scene.MarkSceneEdited(terrain.Scene);
             }
         }
 
@@ -247,7 +259,7 @@ namespace FlaxEditor.Tools.Terrain
 
             var patchCoord = Gizmo.SelectedPatchCoord;
             var chunkCoord = Gizmo.SelectedChunkCoord;
-            var action = new EditChunkMaterialAction(CarveTab.Editor, CarveTab.SelectedTerrain, ref patchCoord, ref chunkCoord, _chunkOverrideMaterial.SelectedAsset as MaterialBase);
+            var action = new EditChunkMaterialAction(CarveTab.SelectedTerrain, ref patchCoord, ref chunkCoord, _chunkOverrideMaterial.SelectedAsset as MaterialBase);
             action.Do();
             CarveTab.Editor.Undo.AddAction(action);
         }

--- a/FlaxEditor/Tools/Terrain/EditTerrainGizmo.cs
+++ b/FlaxEditor/Tools/Terrain/EditTerrainGizmo.cs
@@ -139,21 +139,23 @@ namespace FlaxEditor.Tools.Terrain
             }
         }
 
+        [Serializable]
         private class AddPatchAction : IUndoAction
         {
-            private readonly Editor _editor;
+            [Serialize]
             private Guid _terrainId;
+
+            [Serialize]
             private Int2 _patchCoord;
 
             /// <inheritdoc />
             public string ActionString => "Add terrain patch";
 
-            public AddPatchAction(Editor editor, FlaxEngine.Terrain terrain, ref Int2 patchCoord)
+            public AddPatchAction(FlaxEngine.Terrain terrain, ref Int2 patchCoord)
             {
                 if (terrain == null)
                     throw new ArgumentException(nameof(terrain));
 
-                _editor = editor ?? throw new ArgumentException(nameof(editor));
                 _terrainId = terrain.ID;
                 _patchCoord = patchCoord;
             }
@@ -174,7 +176,7 @@ namespace FlaxEditor.Tools.Terrain
                     Editor.LogError("Failed to initialize terrain patch.");
                 }
 
-                _editor.Scene.MarkSceneEdited(terrain.Scene);
+                Editor.Instance.Scene.MarkSceneEdited(terrain.Scene);
             }
 
             /// <inheritdoc />
@@ -189,7 +191,7 @@ namespace FlaxEditor.Tools.Terrain
 
                 terrain.RemovePatch(ref _patchCoord);
 
-                _editor.Scene.MarkSceneEdited(terrain.Scene);
+                Editor.Instance.Scene.MarkSceneEdited(terrain.Scene);
             }
 
             /// <inheritdoc />
@@ -207,7 +209,7 @@ namespace FlaxEditor.Tools.Terrain
                 if (!terrain.HasPatch(ref patchCoord))
                 {
                     // Add a new patch (with undo)
-                    var action = new AddPatchAction(Editor.Instance, terrain, ref patchCoord);
+                    var action = new AddPatchAction(terrain, ref patchCoord);
                     action.Do();
                     Editor.Instance.Undo.AddAction(action);
                     return true;

--- a/FlaxEditor/Tools/Terrain/Undo/EditTerrainHeightMapAction.cs
+++ b/FlaxEditor/Tools/Terrain/Undo/EditTerrainHeightMapAction.cs
@@ -10,6 +10,7 @@ namespace FlaxEditor.Tools.Terrain.Undo
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
     /// <seealso cref="EditTerrainMapAction" />
+    [Serializable]
     public class EditTerrainHeightMapAction : EditTerrainMapAction
     {
         /// <summary>

--- a/FlaxEditor/Tools/Terrain/Undo/EditTerrainHolesMapAction.cs
+++ b/FlaxEditor/Tools/Terrain/Undo/EditTerrainHolesMapAction.cs
@@ -10,6 +10,7 @@ namespace FlaxEditor.Tools.Terrain.Undo
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
     /// <seealso cref="EditTerrainMapAction" />
+    [Serializable]
     public class EditTerrainHolesMapAction : EditTerrainMapAction
     {
         /// <summary>

--- a/FlaxEditor/Tools/Terrain/Undo/EditTerrainMapAction.cs
+++ b/FlaxEditor/Tools/Terrain/Undo/EditTerrainMapAction.cs
@@ -15,7 +15,7 @@ namespace FlaxEditor.Tools.Terrain.Undo
     public abstract class EditTerrainMapAction : IUndoAction
     {
         [Serializable]
-        private struct PatchData
+        protected struct PatchData
         {
             public Int2 PatchCoord;
             public IntPtr Before;
@@ -41,8 +41,11 @@ namespace FlaxEditor.Tools.Terrain.Undo
         [Serialize]
         protected readonly int _heightmapDataSize;
 
+        /// <summary>
+        /// The terrain patches
+        /// </summary>
         [Serialize]
-        private readonly List<PatchData> _patches;
+        protected readonly List<PatchData> _patches;
 
         /// <summary>
         /// Gets a value indicating whether this action has any modification to the terrain (recorded patches changes).

--- a/FlaxEditor/Tools/Terrain/Undo/EditTerrainMapAction.cs
+++ b/FlaxEditor/Tools/Terrain/Undo/EditTerrainMapAction.cs
@@ -11,8 +11,10 @@ namespace FlaxEditor.Tools.Terrain.Undo
     /// The terrain heightmap or visibility map editing action that records before and after states to swap between unmodified and modified terrain data.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public abstract class EditTerrainMapAction : IUndoAction
     {
+        [Serializable]
         private struct PatchData
         {
             public Int2 PatchCoord;
@@ -24,28 +26,34 @@ namespace FlaxEditor.Tools.Terrain.Undo
         /// <summary>
         /// The terrain (actor Id).
         /// </summary>
+        [Serialize]
         protected readonly Guid _terrain;
 
         /// <summary>
         /// The heightmap length (vertex count).
         /// </summary>
+        [Serialize]
         protected readonly int _heightmapLength;
 
         /// <summary>
         /// The heightmap data size (in bytes).
         /// </summary>
+        [Serialize]
         protected readonly int _heightmapDataSize;
 
+        [Serialize]
         private readonly List<PatchData> _patches;
 
         /// <summary>
         /// Gets a value indicating whether this action has any modification to the terrain (recorded patches changes).
         /// </summary>
+        [NoSerialize]
         public bool HasAnyModification => _patches.Count > 0;
 
         /// <summary>
         /// Gets the terrain.
         /// </summary>
+        [NoSerialize]
         public FlaxEngine.Terrain Terrain
         {
             get

--- a/FlaxEditor/Tools/Terrain/Undo/EditTerrainSplatMapAction.cs
+++ b/FlaxEditor/Tools/Terrain/Undo/EditTerrainSplatMapAction.cs
@@ -10,6 +10,7 @@ namespace FlaxEditor.Tools.Terrain.Undo
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
     /// <seealso cref="EditTerrainMapAction" />
+    [Serializable]
     public class EditTerrainSplatMapAction : EditTerrainMapAction
     {
         /// <summary>

--- a/FlaxEditor/Undo/Actions/AddRemoveScriptAction.cs
+++ b/FlaxEditor/Undo/Actions/AddRemoveScriptAction.cs
@@ -10,17 +10,37 @@ namespace FlaxEditor.Actions
     /// Implementation of <see cref="IUndoAction"/> used to add/remove <see cref="Script"/> from the <see cref="Actor"/>.
     /// </summary>
     /// <seealso cref="IUndoAction" />
+    [Serializable]
     public sealed class AddRemoveScript : IUndoAction
     {
+        [Serialize]
         private bool _isAdd;
+
+        [Serialize]
         private Script _script;
+
+        [Serialize]
         private Guid _scriptId;
+
+        [Serialize]
         private Guid _prefabId;
+
+        [Serialize]
         private Guid _prefabObjectId;
+
+        [Serialize]
         private Type _scriptType;
+
+        [Serialize]
         private string _scriptData;
+
+        [Serialize]
         private Guid _parentId;
+
+        [Serialize]
         private int _orderInParent;
+
+        [Serialize]
         private bool _enabled;
 
         internal AddRemoveScript(bool isAdd, Script script)

--- a/FlaxEditor/Undo/Actions/BreakPrefabLinkAction.cs
+++ b/FlaxEditor/Undo/Actions/BreakPrefabLinkAction.cs
@@ -14,11 +14,19 @@ namespace FlaxEditor.Actions
     /// This action assumes that all objects in the given actor hierarchy are using the same prefab asset.
     /// </remarks>
     /// <seealso cref="IUndoAction" />
+    [Serializable]
     public sealed class BreakPrefabLinkAction : IUndoAction
     {
+        [Serialize]
         private readonly bool _isBreak;
+
+        [Serialize]
         private Guid _actorId;
+
+        [Serialize]
         private Guid _prefabId;
+
+        [Serialize]
         private Dictionary<Guid, Guid> _prefabObjectIds;
 
         private BreakPrefabLinkAction(bool isBreak, Guid actorId, Guid prefabId)

--- a/FlaxEditor/Undo/Actions/ChangeScriptAction.cs
+++ b/FlaxEditor/Undo/Actions/ChangeScriptAction.cs
@@ -11,12 +11,22 @@ namespace FlaxEditor.Actions
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
     /// <seealso cref="FlaxEditor.ISceneEditAction" />
+    [Serializable]
     public class ChangeScriptAction : IUndoAction, ISceneEditAction
     {
+        [Serialize]
         private Guid _scriptId;
+
+        [Serialize]
         private bool _enableA;
+
+        [Serialize]
         private int _orderA;
+
+        [Serialize]
         private bool _enableB;
+
+        [Serialize]
         private int _orderB;
 
         private ChangeScriptAction(Script script, bool enable, int order)

--- a/FlaxEditor/Undo/Actions/DeleteActorsAction.cs
+++ b/FlaxEditor/Undo/Actions/DeleteActorsAction.cs
@@ -11,16 +11,25 @@ namespace FlaxEditor.Actions
     /// Implementation of <see cref="IUndoAction"/> used to delete a selection of <see cref="ActorNode"/>.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public class DeleteActorsAction : IUndoAction
     {
+        [Serialize]
         private byte[] _data;
+
+        [Serialize]
         private Guid[] _prefabIds;
+
+        [Serialize]
         private Guid[] _prefabObjectIds;
+
+        [Serialize]
         private bool _isInverted;
 
         /// <summary>
         /// The node parents.
         /// </summary>
+        [Serialize]
         protected List<ActorNode> _nodeParents;
 
         /// <summary>

--- a/FlaxEditor/Undo/Actions/PasteActorsAction.cs
+++ b/FlaxEditor/Undo/Actions/PasteActorsAction.cs
@@ -12,15 +12,22 @@ namespace FlaxEditor.Actions
     /// Implementation of <see cref="IUndoAction"/> used to paste a set of <see cref="ActorNode"/>.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public class PasteActorsAction : IUndoAction
     {
+        [Serialize]
         private Dictionary<Guid, Guid> _idsMapping;
+
+        [Serialize]
         private byte[] _data;
+
+        [Serialize]
         private Guid _pasteParent;
 
         /// <summary>
         /// The node parents.
         /// </summary>
+        [Serialize]
         protected List<Guid> _nodeParents;
 
         /// <summary>

--- a/FlaxEditor/Undo/MultiUndoAction.cs
+++ b/FlaxEditor/Undo/MultiUndoAction.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FlaxEngine;
 
 namespace FlaxEditor
 {
@@ -10,11 +11,13 @@ namespace FlaxEditor
     /// Implementation of <see cref="IUndoAction"/> that contains one or more child actions performed at once. Allows to merge different actions.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public class MultiUndoAction : IUndoAction
     {
         /// <summary>
         /// The child actions.
         /// </summary>
+        [Serialize]
         public readonly IUndoAction[] Actions;
 
         /// <summary>

--- a/FlaxEditor/Undo/SelectionChangeAction.cs
+++ b/FlaxEditor/Undo/SelectionChangeAction.cs
@@ -9,6 +9,7 @@ namespace FlaxEditor
     /// Objects selection change action.
     /// </summary>
     /// <seealso cref="IUndoAction" />
+    [Serializable]
     public class SelectionChangeAction : UndoActionBase<SelectionChangeAction.DataStorage>
     {
         /// <summary>
@@ -30,7 +31,13 @@ namespace FlaxEditor
 
         private Action<SceneGraphNode[]> _callback;
 
-        internal SelectionChangeAction(SceneGraphNode[] before, SceneGraphNode[] after, Action<SceneGraphNode[]> callback)
+        /// <summary>
+        /// User selection has changed
+        /// </summary>
+        /// <param name="before">Previously selected nodes</param>
+        /// <param name="after">Newly selected nodes</param>
+        /// <param name="callback">Selection change callback</param>
+        public SelectionChangeAction(SceneGraphNode[] before, SceneGraphNode[] after, Action<SceneGraphNode[]> callback)
         {
             Data = new DataStorage
             {

--- a/FlaxEditor/Undo/TransformObjectsAction.cs
+++ b/FlaxEditor/Undo/TransformObjectsAction.cs
@@ -14,6 +14,7 @@ namespace FlaxEditor
     /// Since we use this kind of action very ofter (for <see cref="FlaxEditor.Gizmo.TransformGizmo"/> operations) it's better to provide faster implementation.
     /// </summary>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public sealed class TransformObjectsAction : UndoActionBase<TransformObjectsAction.DataStorage>, ISceneEditAction
     {
         /// <summary>

--- a/FlaxEditor/Undo/UndoActionBase.cs
+++ b/FlaxEditor/Undo/UndoActionBase.cs
@@ -45,8 +45,10 @@ namespace FlaxEditor
     /// </summary>
     /// <typeparam name="TData">The type of the data. Must have <see cref="SerializableAttribute"/>.</typeparam>
     /// <seealso cref="FlaxEditor.IUndoAction" />
+    [Serializable]
     public abstract class UndoActionBase<TData> : IUndoAction where TData : struct
     {
+        [Serialize]
         private string _data;
 
         /// <summary>
@@ -55,6 +57,7 @@ namespace FlaxEditor
         /// <value>
         /// The data.
         /// </value>
+        [NoSerialize]
         public TData Data
         {
             get => JsonConvert.DeserializeObject<TData>(_data, JsonSerializer.Settings);

--- a/FlaxEditor/Undo/UndoActionBase.cs
+++ b/FlaxEditor/Undo/UndoActionBase.cs
@@ -49,7 +49,7 @@ namespace FlaxEditor
     public abstract class UndoActionBase<TData> : IUndoAction where TData : struct
     {
         [Serialize]
-        private string _data;
+        protected string _data;
 
         /// <summary>
         /// Gets or sets the serialized undo data.


### PR DESCRIPTION
This makes almost all classes implementing `IUndoAction` serializeable. 


All classes except:
- [`CustomPasteActorsAction`](https://github.com/FlaxEngine/FlaxAPI/blob/36aa542d564c7b4f1d1115482730e9949c956749/FlaxEditor/Windows/Assets/PrefabWindow.Actions.cs#L144): This one is currently only used for prefabs
- [`SelectionChangeAction`](https://github.com/FlaxEngine/FlaxAPI/blob/master/FlaxEditor/Undo/SelectionChangeAction.cs): This one has [a callback method](https://github.com/FlaxEngine/FlaxAPI/blob/404bb26d48ac518eb8cfada33a2c9eb58f24e0e3/FlaxEditor/Undo/SelectionChangeAction.cs#L31) which can't be serialized. In the non-prefab case, it's currently always `Editor.Instance.SceneEditing`. This means that it's easy enough to handle it manually if someone wants to serialize this.
- [`UndoActionObject`](https://github.com/FlaxEngine/FlaxAPI/blob/master/FlaxEditor/History/UndoActionObject.cs): Serializing this one is hard. Whoever wants to do so has to do it manually.
[Here is an example which works ok-ish.](https://github.com/JimiVacarians/FlaxAPI-MultiUsersEditing/blob/e15b999bb8c73bb90d7b5504f183c126df95698f/Source/MultiUsersEditingPlugin/UndoActionObjectSerializer.cs#L92) Note how serializing `FieldInfo`s and `PropertyInfo`s has been done manually.
