### PR TITLE
Visject improvements 3

### DIFF
--- a/FlaxEditor/Surface/Archetypes/Animation.StateMachine.cs
+++ b/FlaxEditor/Surface/Archetypes/Animation.StateMachine.cs
@@ -364,7 +364,7 @@ namespace FlaxEditor.Surface.Archetypes
             /// <inheritdoc />
             public override bool CanSelect(ref Vector2 location)
             {
-                return _dragAreaRect.MakeOffseted(Location).Contains(ref location);
+                return _dragAreaRect.MakeOffsetted(Location).Contains(ref location);
             }
 
             /// <inheritdoc />
@@ -1159,7 +1159,7 @@ namespace FlaxEditor.Surface.Archetypes
             /// <inheritdoc />
             public override bool CanSelect(ref Vector2 location)
             {
-                return _dragAreaRect.MakeOffseted(Location).Contains(ref location);
+                return _dragAreaRect.MakeOffsetted(Location).Contains(ref location);
             }
 
             /// <inheritdoc />

--- a/FlaxEditor/Surface/Archetypes/Textures.cs
+++ b/FlaxEditor/Surface/Archetypes/Textures.cs
@@ -69,6 +69,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 2,
                 Title = "Texcoords",
+                AlternativeTitles = new string[] { "UV", "UVs" },
                 Description = "Texture coordinates",
                 Flags = NodeFlags.MaterialGraph,
                 Size = new Vector2(110, 30),

--- a/FlaxEditor/Surface/Archetypes/Tools.cs
+++ b/FlaxEditor/Surface/Archetypes/Tools.cs
@@ -727,6 +727,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 11,
                 Title = "Comment",
+                AlternativeTitles = new string[] { "//" },
                 Create = (id, context, arch, groupArch) => new SurfaceComment(id, context, arch, groupArch),
                 Flags = NodeFlags.AllGraphs,
                 Size = new Vector2(400.0f, 400.0f),

--- a/FlaxEditor/Surface/Archetypes/Tools.cs
+++ b/FlaxEditor/Surface/Archetypes/Tools.cs
@@ -728,6 +728,22 @@ namespace FlaxEditor.Surface.Archetypes
                 TypeID = 11,
                 Title = "Comment",
                 AlternativeTitles = new string[] { "//" },
+                TryParseText = (string filterText, out object[] data) => {
+                    data = null;
+                    if(filterText.StartsWith("//"))
+                    {
+                        data = new object[] {
+                            filterText.Substring(2),
+                            new Color(1.0f, 1.0f, 1.0f, 0.2f),
+                            new Vector2(400.0f, 400.0f),
+                        };
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                },
                 Create = (id, context, arch, groupArch) => new SurfaceComment(id, context, arch, groupArch),
                 Flags = NodeFlags.AllGraphs,
                 Size = new Vector2(400.0f, 400.0f),

--- a/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
+++ b/FlaxEditor/Surface/ContextMenu/VisjectCMItem.cs
@@ -106,12 +106,15 @@ namespace FlaxEditor.Surface.ContextMenu
             if (!startBox.IsOutput)
                 return false; // For now, I'm only handing the output box case
 
-            for (int i = 0; i < nodeArchetype.Elements.Length; i++)
+            if (nodeArchetype.Elements != null)
             {
-                if (nodeArchetype.Elements[i].Type == NodeElementType.Input &&
-                    startBox.CanUseType(nodeArchetype.Elements[i].ConnectionsType))
+                for (int i = 0; i < nodeArchetype.Elements.Length; i++)
                 {
-                    return true;
+                    if (nodeArchetype.Elements[i].Type == NodeElementType.Input &&
+                        startBox.CanUseType(nodeArchetype.Elements[i].ConnectionsType))
+                    {
+                        return true;
+                    }
                 }
             }
             return false;
@@ -151,7 +154,7 @@ namespace FlaxEditor.Surface.ContextMenu
                     }
                     Visible = true;
                 }
-                else if (_archetype.AlternativeTitles?.Any(filterText.Equals) == true)
+                else if (_archetype.AlternativeTitles?.Any(altTitle => string.Equals(filterText, altTitle, StringComparison.CurrentCultureIgnoreCase)) == true)
                 {
                     // Update highlights
                     if (_highlights == null)

--- a/FlaxEditor/Surface/Elements/Box.cs
+++ b/FlaxEditor/Surface/Elements/Box.cs
@@ -15,6 +15,8 @@ namespace FlaxEditor.Surface.Elements
     /// <seealso cref="IConnectionInstigator" />
     public abstract class Box : SurfaceNodeElementControl, IConnectionInstigator
     {
+        private bool _isMouseDown;
+
         /// <summary>
         /// The current connection type. It's subset or equal to <see cref="DefaultType"/>.
         /// </summary>
@@ -24,6 +26,11 @@ namespace FlaxEditor.Surface.Elements
         /// The cached color for the current box type.
         /// </summary>
         protected Color _currentTypeColor;
+
+        /// <summary>
+        /// The is selected flag for the box.
+        /// </summary>
+        protected bool _isSelected;
 
         /// <summary>
         /// Unique box ID within single node.
@@ -124,6 +131,15 @@ namespace FlaxEditor.Surface.Elements
         /// Event called when the current type of the box gets changed.
         /// </summary>
         public Action<Box> CurrentTypeChanged;
+
+        /// <summary>
+        /// Gets a value indicating whether this box is selected.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => _isSelected;
+            internal set { _isSelected = value; OnSelectionChanged(); }
+        }
 
         /// <inheritdoc />
         protected Box(SurfaceNode parentNode, NodeElementArchetype archetype, Vector2 location)
@@ -352,6 +368,14 @@ namespace FlaxEditor.Surface.Elements
         {
         }
 
+        protected virtual void OnSelectionChanged()
+        {
+            if (IsSelected && !ParentNode.IsSelected)
+            {
+                ParentNode.Surface.AddToSelection(ParentNode);
+            }
+        }
+
         /// <summary>
         /// Draws the box GUI using <see cref="Render2D"/>.
         /// </summary>
@@ -378,6 +402,13 @@ namespace FlaxEditor.Surface.Elements
             else
                 icon = hasConnections ? style.Icons.BoxClose : style.Icons.BoxOpen;
             Render2D.DrawSprite(icon, rect, color);
+
+            if (IsSelected)
+            {
+                float outlineWidth = 2;
+                var outlineRect = new Rectangle(rect.X - outlineWidth, rect.Y - outlineWidth, rect.Width + outlineWidth * 2, rect.Height + outlineWidth * 2);
+                Render2D.DrawSprite(icon, outlineRect, FlaxEngine.GUI.Style.Current.BorderSelected);
+            }
         }
 
         /// <inheritdoc />
@@ -385,10 +416,20 @@ namespace FlaxEditor.Surface.Elements
         {
             if (buttons == MouseButton.Left)
             {
-                Surface.ConnectingStart(this);
+                _isMouseDown = true;
             }
 
             return true;
+        }
+
+        public override void OnMouseLeave()
+        {
+            if (_isMouseDown)
+            {
+                _isMouseDown = false;
+                Surface.ConnectingStart(this);
+            }
+            base.OnMouseLeave();
         }
 
         /// <inheritdoc />
@@ -405,7 +446,31 @@ namespace FlaxEditor.Surface.Elements
 
             if (buttons == MouseButton.Left)
             {
-                Surface.ConnectingEnd(this);
+                _isMouseDown = false;
+                if (Surface.IsConnecting)
+                {
+                    Surface.ConnectingEnd(this);
+                }
+                else
+                {
+                    // Click
+
+                    if (Root.GetKey(Keys.Control))
+                    {
+                        // Add to selection
+                        if (!ParentNode.IsSelected)
+                        {
+                            ParentNode.Surface.AddToSelection(ParentNode);
+                        }
+                        ParentNode.AddBoxToSelection(this);
+                    }
+                    else
+                    {
+                        // Forcibly select the node
+                        ParentNode.Surface.Select(ParentNode);
+                        ParentNode.SelectBox(this);
+                    }
+                }
                 result = true;
             }
 

--- a/FlaxEditor/Surface/Elements/Box.cs
+++ b/FlaxEditor/Surface/Elements/Box.cs
@@ -414,12 +414,16 @@ namespace FlaxEditor.Surface.Elements
         /// <inheritdoc />
         public override bool OnMouseDown(Vector2 location, MouseButton buttons)
         {
+            if (base.OnMouseDown(location, buttons))
+                return true;
+
             if (buttons == MouseButton.Left)
             {
                 _isMouseDown = true;
+                Focus();
+                return true;
             }
-
-            return true;
+            return false;
         }
 
         public override void OnMouseLeave()
@@ -442,7 +446,8 @@ namespace FlaxEditor.Surface.Elements
         /// <inheritdoc />
         public override bool OnMouseUp(Vector2 location, MouseButton buttons)
         {
-            bool result = false;
+            if (base.OnMouseUp(location, buttons))
+                return true;
 
             if (buttons == MouseButton.Left)
             {
@@ -471,10 +476,10 @@ namespace FlaxEditor.Surface.Elements
                         ParentNode.SelectBox(this);
                     }
                 }
-                result = true;
+                return true;
             }
 
-            return result;
+            return false;
         }
 
         /// <inheritdoc />

--- a/FlaxEditor/Surface/SurfaceComment.cs
+++ b/FlaxEditor/Surface/SurfaceComment.cs
@@ -94,13 +94,13 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool CanSelect(ref Vector2 location)
         {
-            return _headerRect.MakeOffseted(Location).Contains(ref location) && !_resizeButtonRect.MakeOffseted(Location).Contains(ref location);
+            return _headerRect.MakeOffsetted(Location).Contains(ref location) && !_resizeButtonRect.MakeOffsetted(Location).Contains(ref location);
         }
 
         /// <inheritdoc />
         public override bool IsSelectionIntersecting(ref Rectangle selectionRect)
         {
-            return _headerRect.MakeOffseted(Location).Intersects(ref selectionRect);
+            return _headerRect.MakeOffsetted(Location).Intersects(ref selectionRect);
         }
 
         /// <inheritdoc />

--- a/FlaxEditor/Surface/SurfaceComment.cs
+++ b/FlaxEditor/Surface/SurfaceComment.cs
@@ -248,13 +248,18 @@ namespace FlaxEditor.Surface
             // Rename
             if (_headerRect.Contains(ref location))
             {
-                Surface.Select(this);
-                var dialog = RenamePopup.Show(this, _headerRect, Title, false);
-                dialog.Renamed += OnRenamed;
+                StartRenaming();
                 return true;
             }
 
             return false;
+        }
+
+        public void StartRenaming()
+        {
+            Surface.Select(this);
+            var dialog = RenamePopup.Show(this, _headerRect, Title, false);
+            dialog.Renamed += OnRenamed;
         }
 
         private void OnRenamed(RenamePopup renamePopup)

--- a/FlaxEditor/Surface/SurfaceControl.cs
+++ b/FlaxEditor/Surface/SurfaceControl.cs
@@ -1,5 +1,8 @@
 // Copyright (c) 2012-2019 Wojciech Figat. All rights reserved.
 
+using System;
+using System.Collections.Generic;
+using FlaxEditor.Surface.Elements;
 using FlaxEngine;
 using FlaxEngine.GUI;
 
@@ -37,7 +40,7 @@ namespace FlaxEditor.Surface
         public bool IsSelected
         {
             get => _isSelected;
-            internal set { _isSelected = value; }
+            internal set { _isSelected = value; OnSelectionChanged(); }
         }
 
         /// <summary>
@@ -88,6 +91,14 @@ namespace FlaxEditor.Surface
         public virtual bool IsSelectionIntersecting(ref Rectangle selectionRect)
         {
             return Bounds.Intersects(ref selectionRect);
+        }
+
+        /// <summary>
+        /// Called after <see cref="IsSelected"/> changes
+        /// </summary>
+        protected virtual void OnSelectionChanged()
+        {
+
         }
 
         /// <summary>

--- a/FlaxEditor/Surface/SurfaceNode.cs
+++ b/FlaxEditor/Surface/SurfaceNode.cs
@@ -391,6 +391,31 @@ namespace FlaxEditor.Surface
             }
         }
 
+        internal Box GetNextBox(Box box)
+        {
+            int i = 0;
+            for (; i < Elements.Count; i++)
+            {
+                if (Elements[i] == box)
+                {
+                    // We found the box
+                    break;
+                }
+            }
+
+            // Get the one after it
+            i++;
+            for (; i < Elements.Count; i++)
+            {
+                if (Elements[i] is Box b)
+                {
+                    return b;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Selects all the boxes.
         /// </summary>

--- a/FlaxEditor/Surface/SurfaceNode.cs
+++ b/FlaxEditor/Surface/SurfaceNode.cs
@@ -392,6 +392,81 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
+        /// Selects all the boxes.
+        /// </summary>
+        public void SelectAllBoxes()
+        {
+            for (int i = 0; i < Elements.Count; i++)
+            {
+                if (Elements[i] is Box box)
+                    box.IsSelected = true;
+            }
+        }
+
+        /// <summary>
+        /// Clears the box selection.
+        /// </summary>
+        public void ClearBoxSelection()
+        {
+            for (int i = 0; i < Elements.Count; i++)
+            {
+                if (Elements[i] is Box box)
+                    box.IsSelected = false;
+            }
+        }
+
+        /// <summary>
+        /// Adds the specified box to the selection.
+        /// </summary>
+        /// <param name="box">The box.</param>
+        public void AddBoxToSelection(Box box)
+        {
+            box.IsSelected = true;
+        }
+
+        /// <summary>
+        /// Selects the specified control.
+        /// </summary>
+        /// <param name="box">The box.</param>
+        public void SelectBox(Box box)
+        {
+            ClearBoxSelection();
+
+            box.IsSelected = true;
+        }
+
+        /// <summary>
+        /// Selects the specified controls collection.
+        /// </summary>
+        /// <param name="boxes">The boxes.</param>
+        public void SelectBoxes(IEnumerable<Box> boxes)
+        {
+            ClearBoxSelection();
+
+            foreach (var box in boxes)
+            {
+                box.IsSelected = true;
+            }
+        }
+
+        /// <summary>
+        /// Deselects the specified control.
+        /// </summary>
+        /// <param name="box">The box.</param>
+        public void DeselectBox(Box box)
+        {
+            box.IsSelected = false;
+        }
+
+        protected override void OnSelectionChanged()
+        {
+            if (!IsSelected)
+            {
+                ClearBoxSelection();
+            }
+        }
+
+        /// <summary>
         /// Implementation of Depth-First traversal over the graph of surface nodes.
         /// </summary>
         /// <returns>The list of nodes as a result of depth-first traversal algorithm execution.</returns>
@@ -506,7 +581,7 @@ namespace FlaxEditor.Surface
         /// <inheritdoc />
         public override bool CanSelect(ref Vector2 location)
         {
-            return _headerRect.MakeOffseted(Location).Contains(ref location);
+            return _headerRect.MakeOffsetted(Location).Contains(ref location);
         }
 
         /// <inheritdoc />

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -140,7 +140,7 @@ namespace FlaxEditor.Surface
                 return;
 
             // If the user entered a comment
-            if (node is SurfaceComment surfaceComment)
+            if (node is SurfaceComment surfaceComment && HasNodesSelection)
             {
                 // Note how the user input exactly mimics the other comment creation way. This is very much desired.
                 // Select node --> Type // --> Type the comment text --> Hit Enter

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -18,6 +18,7 @@ namespace FlaxEditor.Surface
         private ContextMenuButton _cmDeleteButton;
         private ContextMenuButton _cmRemoveNodeConnectionsButton;
         private ContextMenuButton _cmRemoveBoxConnectionsButton;
+        private readonly Vector2 ContextMenuOffset = new Vector2(5);
 
         /// <summary>
         /// Gets a value indicating whether the primary surface context menu is being opened (eg. user is adding nodes).
@@ -84,10 +85,10 @@ namespace FlaxEditor.Surface
                 _activeVisjectCM.VisibleChanged += OnPrimaryMenuVisibleChanged;
             }
 
-            // Offset added in case the user doesn't like the box and wants to quickly get rid of it by clicking
-            location += new Vector2(5);
-            _activeVisjectCM.Show(this, location, _connectionInstigator as Box);
+            // Show primary menu
             _cmStartPos = location;
+            // Offset added in case the user doesn't like the box and wants to quickly get rid of it by clicking
+            _activeVisjectCM.Show(this, location + ContextMenuOffset, _connectionInstigator as Box);
         }
 
         /// <summary>
@@ -137,6 +138,17 @@ namespace FlaxEditor.Surface
             );
             if (node == null)
                 return;
+
+            // If the user entered a comment
+            if (node is SurfaceComment surfaceComment)
+            {
+                // Note how the user input exactly mimics the other comment creation way. This is very much desired.
+                // Select node --> Type // --> Type the comment text --> Hit Enter
+                string title = surfaceComment.Title;
+                Delete(node);
+                CommentSelection(title);
+                return;
+            }
 
             // Auto select new node
             Select(node);
@@ -210,6 +222,8 @@ namespace FlaxEditor.Surface
                     }
                 }
             }
+
+
 
             // Disable intelligent connecting for now
             /*

--- a/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
+++ b/FlaxEditor/Surface/VisjectSurface.ContextMenu.cs
@@ -182,85 +182,6 @@ namespace FlaxEditor.Surface
                 }
                 TryConnect(selectedBox, endBox);
             }
-
-            // Disable intelligent connecting for now
-            /*
-            var toBeDeselected = new System.Collections.Generic.List<SurfaceNode>();
-
-            using (var outputBoxes = Selection
-                                     .OrderBy(n => n.Top)
-                                     .SelectMany(n => n.GetBoxes())
-                                     .Where(b => b.IsOutput && !b.HasAnyConnection)
-                                     .GetEnumerator())
-            {
-                // For each input box (I'm assuming that they are sorted properly)
-                foreach (var inputBox in node.GetBoxes().Where(box => !box.IsOutput))
-                {
-                    Box connectWith = null;
-
-                    // Find the next decent output box and connect them
-                    while (connectWith == null && outputBoxes.MoveNext())
-                    {
-                        var outputBox = outputBoxes.Current;
-                        bool connectAnyways = true;
-
-                        // Can I rely on the box indices?
-                        // If it's a constant node, it needs some special handling (either connect the first box or the other ones, never both)
-                        if (outputBox.ParentNode.GroupArchetype.Name == "Constants")
-                        {
-                            // Don't always connect this sort of box
-                            connectAnyways = false;
-
-                            // If it's the first box, everything is fine?
-                            if (outputBox.ID == 0)
-                            {
-                                // Everything is fine
-                                // If this one doesn't have any alternatives, I can just connect it regardless of the consequences
-                                if (outputBox.ParentNode.Elements.Count(e => e is Box) <= 1)
-                                {
-                                    connectAnyways = true;
-                                }
-                            }
-                            // It's an alternative box
-                            else
-                            {
-                                // The first one is already connected => skip this one!
-                                if (outputBox.ParentNode.Get(0).HasAnyConnection)
-                                {
-                                    continue;
-                                }
-                                else
-                                {
-                                    // It's an actual alternative
-                                }
-                            }
-                        }
-
-                        // If they can easily be connected, just do it ✔
-                        if ((inputBox.CurrentType & outputBox.CurrentType) != 0)
-                        {
-                            connectWith = outputBox;
-                        }
-                        else if (connectAnyways && inputBox.CanUseType(outputBox.CurrentType))
-                        {
-                            connectWith = outputBox;
-                        }
-                    }
-                    if (connectWith != null)
-                    {
-                        // Connect them
-                        connectWith.CreateConnection(inputBox);
-                        toBeDeselected.Add(connectWith.ParentNode);
-                    }
-                }
-            }
-
-            foreach (var toDeselect in toBeDeselected)
-            {
-                Deselect(toDeselect);
-            }
-
-            */
         }
 
         private void TryConnect(Box startBox, Box endBox)
@@ -293,7 +214,7 @@ namespace FlaxEditor.Surface
              * Input and Input => undefined, cannot happen
              */
             Box inputBox = endBox.IsOutput ? startBox : endBox;
-            Box nextBox = GetNextBox(inputBox);
+            Box nextBox = inputBox.ParentNode.GetNextBox(inputBox);
 
             // If we are going backwards and the end-node has an input box
             //   we want to edit backwards

--- a/FlaxEditor/Surface/VisjectSurface.Draw.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Draw.cs
@@ -133,16 +133,48 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
-        /// Draws the unfinished connections for the brackets
+        /// Draws the brackets and connections
         /// </summary>
-        private void DrawInputBrackets()
+        protected virtual void DrawInputBrackets()
         {
-            // TODO:
-            /*foreach (var box in _inputBracketsStack)
-                {
-                    Vector2 pos = box.ParentNode.PointToParent(_rootControl.Parent, box.Location);
-                    Render2D.DrawText(style.FontTitle, "{}", new Rectangle(pos, 10, 10), Color.YellowGreen);
-                }*/
+            var style = FlaxEngine.GUI.Style.Current;
+            foreach (var inputBracket in _inputBrackets)
+            {
+                // Draw brackets
+                Vector2 upperLeft = _rootControl.PointToParent(inputBracket.Area.UpperLeft);
+                Vector2 bottomRight = _rootControl.PointToParent(inputBracket.Area.BottomRight);
+
+                Vector2 upperRight = new Vector2(bottomRight.X, upperLeft.Y);
+                Vector2 bottomLeft = new Vector2(upperLeft.X, bottomRight.Y);
+
+                // Calculate control points
+                float height = bottomLeft.Y - upperLeft.Y;
+                float offsetX = height / 10f;
+                Vector2 leftControl1 = new Vector2(bottomLeft.X - offsetX, bottomLeft.Y);
+                Vector2 leftControl2 = new Vector2(upperLeft.X - offsetX, upperLeft.Y);
+
+                // Draw left bracket
+                Render2D.DrawBezier(bottomLeft, leftControl1, leftControl2, upperLeft, style.Foreground, 2.2f);
+
+                // Calculate control points
+                Vector2 rightControl1 = new Vector2(bottomRight.X + offsetX, bottomRight.Y);
+                Vector2 rightControl2 = new Vector2(upperRight.X + offsetX, upperRight.Y);
+
+                // Draw right bracket
+                Render2D.DrawBezier(bottomRight, rightControl1, rightControl2, upperRight, style.Foreground * 0.6f, 2.2f);
+
+                // Draw connection bezier
+                // X-offset at 75%
+                Vector2 bezierStartPoint = new Vector2(upperRight.X + offsetX * 0.75f, (upperRight.Y + bottomRight.Y) * 0.5f);
+                Vector2 bezierEndPoint = inputBracket.Box.ParentNode.PointToParent(_rootControl.Parent, inputBracket.Box.Center);
+                Color color = style.Foreground * 0.6f;
+
+                Elements.OutputBox.DrawConnection(ref bezierStartPoint, ref bezierEndPoint, ref color);
+                // Debug Area
+                //Rectangle drawRect = Rectangle.FromPoints(upperLeft, bottomRight);
+                //Render2D.FillRectangle(drawRect, Color.Green * 0.5f);
+            }
+
         }
 
         /// <summary>
@@ -179,9 +211,9 @@ namespace FlaxEditor.Surface
                 DrawConnectingLine();
             }
 
-            DrawInputBrackets();
-
             Render2D.PopTransform();
+
+            DrawInputBrackets();
 
             DrawContents();
 

--- a/FlaxEditor/Surface/VisjectSurface.Draw.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Draw.cs
@@ -138,6 +138,7 @@ namespace FlaxEditor.Surface
         protected virtual void DrawInputBrackets()
         {
             var style = FlaxEngine.GUI.Style.Current;
+            Color fadedColor = style.Foreground * 0.6f;
             foreach (var inputBracket in _inputBrackets)
             {
                 // Draw brackets
@@ -161,15 +162,14 @@ namespace FlaxEditor.Surface
                 Vector2 rightControl2 = new Vector2(upperRight.X + offsetX, upperRight.Y);
 
                 // Draw right bracket
-                Render2D.DrawBezier(bottomRight, rightControl1, rightControl2, upperRight, style.Foreground * 0.6f, 2.2f);
+                Render2D.DrawBezier(bottomRight, rightControl1, rightControl2, upperRight, fadedColor, 2.2f);
 
                 // Draw connection bezier
                 // X-offset at 75%
                 Vector2 bezierStartPoint = new Vector2(upperRight.X + offsetX * 0.75f, (upperRight.Y + bottomRight.Y) * 0.5f);
                 Vector2 bezierEndPoint = inputBracket.Box.ParentNode.PointToParent(_rootControl.Parent, inputBracket.Box.Center);
-                Color color = style.Foreground * 0.6f;
 
-                Elements.OutputBox.DrawConnection(ref bezierStartPoint, ref bezierEndPoint, ref color);
+                Elements.OutputBox.DrawConnection(ref bezierStartPoint, ref bezierEndPoint, ref fadedColor);
                 // Debug Area
                 //Rectangle drawRect = Rectangle.FromPoints(upperLeft, bottomRight);
                 //Render2D.FillRectangle(drawRect, Color.Green * 0.5f);

--- a/FlaxEditor/Surface/VisjectSurface.Draw.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Draw.cs
@@ -95,17 +95,6 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
-        /// Draws the comment creating background.
-        /// </summary>
-        /// <remarks>Called only when user is creating comment using rectangle tool.</remarks>
-        protected virtual void DrawCommenting()
-        {
-            var selectionRect = Rectangle.FromPoints(_leftMouseDownPos, _mousePos);
-            Render2D.FillRectangle(selectionRect, Color.White * 0.4f);
-            Render2D.DrawRectangle(selectionRect, Color.White);
-        }
-
-        /// <summary>
         /// Draws all the connections between surface nodes.
         /// </summary>
         /// <param name="mousePosition">The current mouse position (in surface-space).</param>
@@ -174,11 +163,7 @@ namespace FlaxEditor.Surface
 
             _rootControl.DrawComments();
 
-            if (IsCreatingComment)
-            {
-                DrawCommenting();
-            }
-            else if (IsSelecting)
+            if (IsSelecting)
             {
                 DrawSelection();
             }

--- a/FlaxEditor/Surface/VisjectSurface.Draw.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Draw.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2019 Wojciech Figat. All rights reserved.
 
+using System;
 using FlaxEngine;
 
 namespace FlaxEditor.Surface
@@ -143,6 +144,19 @@ namespace FlaxEditor.Surface
         }
 
         /// <summary>
+        /// Draws the unfinished connections for the brackets
+        /// </summary>
+        private void DrawInputBrackets()
+        {
+            // TODO:
+            /*foreach (var box in _inputBracketsStack)
+                {
+                    Vector2 pos = box.ParentNode.PointToParent(_rootControl.Parent, box.Location);
+                    Render2D.DrawText(style.FontTitle, "{}", new Rectangle(pos, 10, 10), Color.YellowGreen);
+                }*/
+        }
+
+        /// <summary>
         /// Draws the contents of the surface (nodes, connections, comments, etc.).
         /// </summary>
         protected virtual void DrawContents()
@@ -179,6 +193,8 @@ namespace FlaxEditor.Surface
             {
                 DrawConnectingLine();
             }
+
+            DrawInputBrackets();
 
             Render2D.PopTransform();
 

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -514,6 +514,52 @@ namespace FlaxEditor.Surface
             return true;
         }
 
+        /// <inheritdoc />
+        public override bool OnKeyDown(Keys key)
+        {
+            if (base.OnKeyDown(key))
+                return true;
+
+            if (InputActions.Process(Editor.Instance, this, key))
+                return true;
+
+            if (HasInputSelection)
+            {
+                if (key == Keys.Backspace)
+                {
+                    if (InputText.Length > 0)
+                        InputText = InputText.Substring(0, InputText.Length - 1);
+                    return true;
+                }
+                else if (key == Keys.Escape)
+                {
+                    ClearSelection();
+                }
+                else if (key == Keys.Return)
+                {
+                    Box selectedBox = GetSelectedBox(SelectedNodes);
+                    if (selectedBox != null)
+                    {
+                        Box toSelect = selectedBox.ParentNode.GetNextBox(selectedBox);
+
+                        if (toSelect != null)
+                        {
+                            Select(toSelect.ParentNode);
+                            toSelect.ParentNode.SelectBox(toSelect);
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override void OnKeyUp(Keys key)
+        {
+            base.OnKeyUp(key);
+        }
+
         private void ResetInput()
         {
             InputText = "";
@@ -578,7 +624,7 @@ namespace FlaxEditor.Surface
                 // Opening bracket
                 if (!selectedBox.IsOutput)
                 {
-                    var bracket = new InputBracket(selectedBox, PositionAfterBox(selectedBox));
+                    var bracket = new InputBracket(selectedBox, FindEmptySpace(selectedBox));
                     _inputBrackets.Push(bracket);
                     Deselect(selectedBox.ParentNode);
                 }
@@ -605,7 +651,7 @@ namespace FlaxEditor.Surface
                 ConnectingStart(selectedBox);
                 Cursor = CursorType.Default; // Do I need this?
                 EndMouseCapture();
-                ShowPrimaryMenu(_rootControl.PointToParent(PositionAfterBox(selectedBox)), currentInputText);
+                ShowPrimaryMenu(_rootControl.PointToParent(FindEmptySpace(selectedBox)), currentInputText);
             }
         }
 
@@ -664,7 +710,7 @@ namespace FlaxEditor.Surface
             return selectedBox;
         }
 
-        private Vector2 PositionAfterBox(Box box)
+        private Vector2 FindEmptySpace(Box box)
         {
             int boxIndex = 0;
 
@@ -691,78 +737,6 @@ namespace FlaxEditor.Surface
                 );
 
             return newNodeLocation;
-        }
-
-        private static Box GetNextBox(Box box)
-        {
-            SurfaceNode surfaceNode = box.ParentNode;
-            int i = 0;
-            for (; i < surfaceNode.Elements.Count; i++)
-            {
-                if (surfaceNode.Elements[i] is Box b && b == box)
-                {
-                    // We found the box
-                    break;
-                }
-            }
-
-            // Get the one after it
-            i++;
-            for (; i < surfaceNode.Elements.Count; i++)
-            {
-                if (surfaceNode.Elements[i] is Box b)
-                {
-                    return b;
-                }
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        public override bool OnKeyDown(Keys key)
-        {
-            if (base.OnKeyDown(key))
-                return true;
-
-            if (InputActions.Process(Editor.Instance, this, key))
-                return true;
-
-            if (HasInputSelection)
-            {
-                if (key == Keys.Backspace)
-                {
-                    if (InputText.Length > 0)
-                        InputText = InputText.Substring(0, InputText.Length - 1);
-                    return true;
-                }
-                else if (key == Keys.Escape)
-                {
-                    ClearSelection();
-                }
-                else if (key == Keys.Return)
-                {
-                    Box selectedBox = GetSelectedBox(SelectedNodes);
-                    if (selectedBox != null)
-                    {
-                        Box toSelect = GetNextBox(selectedBox);
-
-                        if (toSelect != null)
-                        {
-                            Select(toSelect.ParentNode);
-                            toSelect.ParentNode.SelectBox(toSelect);
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        /// <inheritdoc />
-        public override void OnKeyUp(Keys key)
-        {
-            base.OnKeyUp(key);
         }
     }
 }

--- a/FlaxEditor/Surface/VisjectSurface.Input.cs
+++ b/FlaxEditor/Surface/VisjectSurface.Input.cs
@@ -316,9 +316,11 @@ namespace FlaxEditor.Surface
                 _isMovingSelection = false;
                 _rightMouseDown = false;
                 _leftMouseDown = false;
-                ResetInput();
                 return true;
             }
+
+            // Just reset the input text whenever the user presses anywhere
+            ResetInput();
 
             // Cache data
             _isMovingSelection = false;

--- a/FlaxEditor/Surface/VisjectSurface.cs
+++ b/FlaxEditor/Surface/VisjectSurface.cs
@@ -31,7 +31,6 @@ namespace FlaxEditor.Surface
 
         private float _targetScale = 1.0f;
         private float _moveViewWithMouseDragSpeed = 1.0f;
-        private bool _wasMouseDownSinceCommentCreatingStart;
         private bool _isReleasing;
         private VisjectCM _activeVisjectCM;
         private GroupArchetype _customNodesGroup;
@@ -46,11 +45,6 @@ namespace FlaxEditor.Surface
         /// The right mouse down flag.
         /// </summary>
         protected bool _rightMouseDown;
-
-        /// <summary>
-        /// The flag for keyboard key down for comment creating.
-        /// </summary>
-        protected bool _isCommentCreateKeyDown;
 
         /// <summary>
         /// The left mouse down position.
@@ -176,22 +170,17 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Gets a value indicating whether user is selecting nodes.
         /// </summary>
-        public bool IsSelecting => _leftMouseDown && !_isMovingSelection && _connectionInstigator == null && !_isCommentCreateKeyDown;
+        public bool IsSelecting => _leftMouseDown && !_isMovingSelection && _connectionInstigator == null;
 
         /// <summary>
         /// Gets a value indicating whether user is moving selected nodes.
         /// </summary>
-        public bool IsMovingSelection => _leftMouseDown && _isMovingSelection && _connectionInstigator == null && !_isCommentCreateKeyDown;
+        public bool IsMovingSelection => _leftMouseDown && _isMovingSelection && _connectionInstigator == null;
 
         /// <summary>
         /// Gets a value indicating whether user is connecting nodes.
         /// </summary>
         public bool IsConnecting => _connectionInstigator != null;
-
-        /// <summary>
-        /// Gets a value indicating whether user is creating comment.
-        /// </summary>
-        public bool IsCreatingComment => _isCommentCreateKeyDown && _leftMouseDown && !_isMovingSelection && _connectionInstigator == null;
 
         /// <summary>
         /// Gets a value indicating whether the left mouse button is down.
@@ -585,11 +574,11 @@ namespace FlaxEditor.Surface
         /// <summary>
         /// Creates the comment around the selected nodes.
         /// </summary>
-        public void CommentSelection()
+        public SurfaceComment CommentSelection(string text = "")
         {
             var selection = SelectedNodes;
             if (selection.Count == 0)
-                return;
+                return null;
 
             Rectangle surfaceArea = selection[0].Bounds.MakeExpanded(80.0f);
             for (int i = 1; i < selection.Count; i++)
@@ -597,7 +586,7 @@ namespace FlaxEditor.Surface
                 surfaceArea = Rectangle.Union(surfaceArea, selection[i].Bounds.MakeExpanded(80.0f));
             }
 
-            _context.CreateComment(ref surfaceArea, "Comment", new Color(1.0f, 1.0f, 1.0f, 0.2f));
+            return _context.CreateComment(ref surfaceArea, string.IsNullOrEmpty(text) ? "Comment" : text, new Color(1.0f, 1.0f, 1.0f, 0.2f));
         }
 
         /// <summary>

--- a/FlaxEditor/Surface/VisjectSurfaceContext.Serialization.cs
+++ b/FlaxEditor/Surface/VisjectSurfaceContext.Serialization.cs
@@ -553,6 +553,7 @@ namespace FlaxEditor.Surface
         public virtual void OnControlSpawned(SurfaceControl control)
         {
             control.OnSpawned();
+            ControlAdded?.Invoke(control);
         }
 
         /// <summary>
@@ -561,6 +562,7 @@ namespace FlaxEditor.Surface
         /// <param name="control">The control.</param>
         public virtual void OnControlDeleted(SurfaceControl control)
         {
+            ControlRemoved?.Invoke(control);
             control.OnDeleted();
         }
 

--- a/FlaxEditor/Surface/VisjectSurfaceContext.cs
+++ b/FlaxEditor/Surface/VisjectSurfaceContext.cs
@@ -120,6 +120,16 @@ namespace FlaxEditor.Surface
         public event ContextModifiedDelegate Modified;
 
         /// <summary>
+        /// Occurs when node gets added
+        /// </summary>
+        public event Action<SurfaceControl> ControlAdded;
+
+        /// <summary>
+        /// Occurs when node gets removed
+        /// </summary>
+        public event Action<SurfaceControl> ControlRemoved;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VisjectSurfaceContext"/> class.
         /// </summary>
         /// <param name="surface">The Visject surface using this context.</param>

--- a/FlaxEngine/Math/Rectangle.cs
+++ b/FlaxEngine/Math/Rectangle.cs
@@ -243,7 +243,7 @@ namespace FlaxEngine
         /// <param name="x">X coordinate offset</param>
         /// <param name="y">Y coordinate offset</param>
         /// <returns>Offseted rectangle</returns>
-        public Rectangle MakeOffseted(float x, float y)
+        public Rectangle MakeOffsetted(float x, float y)
         {
             return new Rectangle(Location + new Vector2(x, y), Size);
         }
@@ -253,7 +253,7 @@ namespace FlaxEngine
         /// </summary>
         /// <param name="offset">X and Y coordinate offset</param>
         /// <returns>Offseted rectangle</returns>
-        public Rectangle MakeOffseted(Vector2 offset)
+        public Rectangle MakeOffsetted(Vector2 offset)
         {
             return new Rectangle(Location + offset, Size);
         }


### PR DESCRIPTION
## Visject Fast Typing

One major issue with Visject as it currently is, is that creating graphs with lots of nodes takes quite a while. You constantly have to reach for the mouse when you want to create a new node, edit a node or connect nodes.

The logical step here would be making it possible to use the keyboard instead of the mouse (⌨️  > 🖱). This is usually done by adding arcane, obscure incantations called keyboard shortcuts.

However, this leads to a new problem: *How the heck are you supposed to remember keyboard shortcuts for every single tool?*

So, enter Visject-Fast-Typing, a super cool approach where you type out what you want and the nodes appear!

Implements the following Visject improvements
- Visject primary menu pops up at the cursor as soon as you start typing
- Boxes can be selected
- Typing after selecting a box (current box) results in the primary menu popping up
- Typing after selecting an output-only box also results in the primary menu
- Newly created nodes are selected by default
- Current box advances after creating a new node
- Comment creation with `//` in the context menu and as a "shortcut"
- Typing brackets `( )` with nodes in them

Outstanding:
- Selected box display (it looks ugly)