### PR TITLE
Show get only properties with the ShowInEditorAttribute

### DIFF
--- a/FlaxEditor/CustomEditors/Editors/GenericEditor.cs
+++ b/FlaxEditor/CustomEditors/Editors/GenericEditor.cs
@@ -141,6 +141,11 @@ namespace FlaxEditor.CustomEditors.Editors
                     // Field declared with `readonly` keyword
                     IsReadOnly = true;
                 }
+                if (!IsReadOnly && info is PropertyInfo propertyInfo && !propertyInfo.CanWrite)
+                {
+                    // Property without a setter
+                    IsReadOnly = true;
+                }
                 if (Display?.Name != null)
                 {
                     // Use name provided by the attribute
@@ -275,10 +280,6 @@ namespace FlaxEditor.CustomEditors.Editors
                         continue;
 
                     var item = new ItemInfo(p, attributes);
-                    if (!p.CanWrite)
-                    {
-                        item.IsReadOnly = true;
-                    }
                     items.Add(item);
                 }
             }

--- a/FlaxEditor/CustomEditors/Editors/GenericEditor.cs
+++ b/FlaxEditor/CustomEditors/Editors/GenericEditor.cs
@@ -265,16 +265,20 @@ namespace FlaxEditor.CustomEditors.Editors
 
                     // Skip only set properties and special cases
                     var getter = p.GetMethod;
-                    if (getter == null || !p.CanWrite || p.GetIndexParameters().GetLength(0) != 0)
+                    if (getter == null || p.GetIndexParameters().GetLength(0) != 0)
                         continue;
 
                     var attributes = p.GetCustomAttributes(true);
 
-                    // Skip hidden properties, handle special attributes
-                    if ((!getter.IsPublic && !attributes.Any(x => x is ShowInEditorAttribute)) || attributes.Any(x => x is HideInEditorAttribute))
+                    // Skip hidden or get only properties, handle special attributes
+                    if (((!getter.IsPublic || !p.CanWrite) && !attributes.Any(x => x is ShowInEditorAttribute)) || attributes.Any(x => x is HideInEditorAttribute))
                         continue;
 
                     var item = new ItemInfo(p, attributes);
+                    if (!p.CanWrite)
+                    {
+                        item.IsReadOnly = true;
+                    }
                     items.Add(item);
                 }
             }


### PR DESCRIPTION
Currently properties without a setter with a `ShowInEditorAttribute` do not show up in the editor. 
```csharp
[ShowInEditor]
public int ComputedInt { get; } = 4;
```
Such properties would be rather useful for things such as displaying the Velocity of the current RigidBody. 

This PR has been implemented according to the suggestions of @klukule and addresses this by displaying properties without a setter, if they have a `ShowInEditorAttribute`