### PR TITLE
Add "if" as alternative title to branch node

### DIFF
--- a/FlaxEditor/Surface/Archetypes/Comparisons.cs
+++ b/FlaxEditor/Surface/Archetypes/Comparisons.cs
@@ -53,6 +53,7 @@ namespace FlaxEditor.Surface.Archetypes
             {
                 TypeID = 7,
                 Title = "Branch",
+                AlternativeTitles = new string[] { "if" },
                 Description = "Returns one of the input values based on the condition value",
                 Flags = NodeFlags.AllGraphs,
                 Size = new Vector2(100, 60),


### PR DESCRIPTION
Added "if" as alternative title to branch node so that it's easier to find the branch node, especially if you come from a traditional shader writing background.